### PR TITLE
Backport changes from cookiecutter-django-girder v0.8

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: ./manage.py migrate
 web: gunicorn --bind 0.0.0.0:$PORT isic.wsgi
-worker: REMAP_SIGTERM=SIGQUIT celery worker --app isic.celery --loglevel info --without-heartbeat
+worker: REMAP_SIGTERM=SIGQUIT celery --app isic.celery worker --loglevel INFO --without-heartbeat

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ but allows developers to run Python code on their native system.
    2. `./manage.py runserver`
 3. Run in a separate terminal:
    1. `source ./dev/source-native-env.sh`
-   2. `celery worker --app isic.celery --loglevel info --without-heartbeat`
+   2. `celery --app isic.celery worker --loglevel INFO --without-heartbeat`
 4. When finished, run `docker-compose stop`
 
 ## Remap Service Ports (optional)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,9 +22,10 @@ services:
       context: .
       dockerfile: ./dev/django.Dockerfile
     command: [
-      "celery", "worker",
+      "celery",
       "--app", "isic.celery",
-      "--loglevel", "info",
+      "worker",
+      "--loglevel", "INFO",
       "--without-heartbeat"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'bcrypt',
-        'celery<5',
+        'celery',
         'django',
         'django-admin-display',
         'django-allauth',

--- a/tox.ini
+++ b/tox.ini
@@ -75,5 +75,3 @@ filterwarnings =
     ignore::DeprecationWarning:configurations
     # The DEFAULT_HASHING_ALGORITHM warning is caused by Django Configurations
     ignore:.*DEFAULT_HASHING_ALGORITHM.*:django.utils.deprecation.RemovedInDjango40Warning:django
-    ignore::django.utils.deprecation.RemovedInDjango40Warning:rest_framework
-    ignore::django.utils.deprecation.RemovedInDjango40Warning:oauth2_provider


### PR DESCRIPTION
https://github.com/girder/cookiecutter-django-girder/releases/tag/v0.8