### PR TITLE
Use django_admin_display to annotate admin fields

### DIFF
--- a/isic/studies/admin.py
+++ b/isic/studies/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.db.models import Count, Exists, OuterRef
+from django_admin_display import admin_display
 from girder_utils.admin import ReadonlyInlineMixin, ReadonlyTabularInline
 import nested_admin
 
@@ -76,10 +77,9 @@ class QuestionChoiceAdmin(admin.ModelAdmin):
         qs = qs.annotate(responded=Count('response'))
         return qs
 
+    @admin_display(admin_order_field='responded')
     def responded(self, obj):
         return obj.responded
-
-    responded.admin_order_field = 'responded'
 
 
 @admin.register(Response)
@@ -112,11 +112,9 @@ class StudyTaskAdmin(nested_admin.NestedModelAdmin):
         qs = super().get_queryset(request)
         return qs.annotate(has_annotation=Exists(Annotation.objects.filter(task=OuterRef('pk'))))
 
+    @admin_display(admin_order_field='has_annotation', boolean=True)
     def complete(self, obj):
-        return obj.has_annotation
-
-    complete.admin_order_field = 'has_annotation'
-    complete.boolean = True
+        return obj.has_annot
 
 
 @admin.register(Study)
@@ -144,30 +142,25 @@ class StudyAdmin(admin.ModelAdmin):
             num_responded=Count('tasks__annotation', distinct=True),
         )
 
+    @admin_display(admin_order_field='num_responded')
     def num_responded(self, obj):
         return obj.num_responded
 
-    num_responded.admin_order_field = 'num_responded'
-
+    @admin_display(admin_order_field='num_tasks')
     def num_tasks(self, obj):
         return obj.num_tasks
 
-    num_tasks.admin_order_field = 'num_tasks'
-
+    @admin_display(admin_order_field='num_images')
     def num_images(self, obj):
         return obj.num_images
 
-    num_images.admin_order_field = 'num_images'
-
+    @admin_display(admin_order_field='num_features')
     def num_features(self, obj):
         return obj.num_features
 
-    num_features.admin_order_field = 'num_features'
-
+    @admin_display(admin_order_field='num_questions')
     def num_questions(self, obj):
         return obj.num_questions
-
-    num_questions.admin_order_field = 'num_questions'
 
 
 @admin.register(Feature)
@@ -197,12 +190,10 @@ class QuestionAdmin(admin.ModelAdmin):
             num_choices=Count('choices'), used_in=Count('study', distinct=True)
         )
 
+    @admin_display(admin_order_field='num_choices')
     def num_choices(self, obj):
         return obj.num_choices
 
-    num_choices.admin_order_field = 'num_choices'
-
+    @admin_display(admin_order_field='used_in')
     def used_in(self, obj):
         return obj.used_in
-
-    used_in.admin_order_field = 'used_in'


### PR DESCRIPTION
We already install the `django_admin_display` to provide this functionality.

This way is more tightly coupled to the fields in question and is safer to use with typechecking.