### PR TITLE
Ensure local templates are still loaded first

### DIFF
--- a/isic/settings.py
+++ b/isic/settings.py
@@ -30,11 +30,9 @@ class IsicMixin(ConfigMixin):
             'nested_admin',
         ]
 
-        # Insert before other apps with allauth templates
-        auth_app_index = configuration.INSTALLED_APPS.index(
-            'composed_configuration.authentication.apps.AuthenticationConfig'
-        )
-        configuration.INSTALLED_APPS.insert(auth_app_index, 'isic.login.apps.LoginConfig')
+        # Insert before other apps with styled templates
+        style_app_index = configuration.INSTALLED_APPS.index('girder_style')
+        configuration.INSTALLED_APPS.insert(style_app_index, 'isic.login.apps.LoginConfig')
 
         if configuration.ISIC_DISCOURSE_SSO_SECRET:
             configuration.INSTALLED_APPS += [

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'django',
         'django-admin-display',
         'django-allauth',
-        'django-composed-configuration[dev,prod]>=0.10.0',
+        'django-composed-configuration[dev,prod]>=0.12.0',
         'django-configurations[database,email]',
         'django-extensions',
         'django-filter',


### PR DESCRIPTION
This adds support for the latest release of `django-composed-configuration`.