### PR TITLE
Improve memory usage for celery tasks

### DIFF
--- a/isic/ingest/tasks.py
+++ b/isic/ingest/tasks.py
@@ -71,14 +71,14 @@ def extract_zip(zip_id):
                             guess_type(original_file_name)[0],
                         ),
                     )
-
         zip.accessions.update(status=Zip.Status.CREATED)
 
-        for accession_id in zip.accessions.values_list('id', flat=True):
-            process_accession.delay(accession_id)
+    # tasks should be delayed after the accessions are committed to the database
+    for accession_id in zip.accessions.values_list('id', flat=True):
+        process_accession.delay(accession_id)
 
-        zip.status = Zip.Status.COMPLETED
-        zip.save(update_fields=['status'])
+    zip.status = Zip.Status.COMPLETED
+    zip.save(update_fields=['status'])
 
 
 @shared_task

--- a/isic/settings.py
+++ b/isic/settings.py
@@ -86,6 +86,8 @@ class IsicMixin(ConfigMixin):
     )
     ISIC_MONGO_URI = values.SecretValue()
 
+    CELERY_WORKER_MAX_TASKS_PER_CHILD = 1
+
 
 class DevelopmentConfiguration(IsicMixin, DevelopmentBaseConfiguration):
     # Development-only settings


### PR DESCRIPTION
@brianhelba I'm not a huge fan of adding this setting but I think we need it. Python/Celery isn't cleaning up RAM after an ingest. Does this LGTY?