### PR TITLE
Always use the GirderBackend, but make ISIC_MONGO_URI optional in development

### DIFF
--- a/isic/login/backends.py
+++ b/isic/login/backends.py
@@ -1,7 +1,9 @@
 import datetime
+import logging
 from typing import Dict, Optional
 
 import bcrypt
+from django.conf import settings
 from django.contrib.auth.backends import ModelBackend
 from django.contrib.auth.hashers import BasePasswordHasher, mask_hash
 from django.contrib.auth.models import User
@@ -9,6 +11,8 @@ from django.http import HttpRequest
 from django.utils.translation import gettext_noop as _
 
 from isic.login.girder import fetch_girder_user_by_email
+
+logger = logging.getLogger(__name__)
 
 
 class GirderPasswordHasher(BasePasswordHasher):
@@ -34,6 +38,10 @@ class GirderBackend(ModelBackend):
     def authenticate(
         self, request: Optional[HttpRequest], username: str = None, password: str = None, **kwargs
     ) -> Optional[User]:
+        if not settings.ISIC_MONGO_URI:
+            logger.warning('No ISIC_MONGO_URI configured; cannot authenticate from Girder.')
+            return None
+
         girder_user = fetch_girder_user_by_email(username)
         if not girder_user:
             return None

--- a/isic/settings.py
+++ b/isic/settings.py
@@ -99,12 +99,7 @@ class DevelopmentConfiguration(IsicMixin, DevelopmentBaseConfiguration):
         'from isic.ingest.validators import *',
     ]
 
-    # Development-specific overrides
-    AUTHENTICATION_BACKENDS = [
-        'allauth.account.auth_backends.AuthenticationBackend',
-    ]
-
-    ISIC_MONGO_URI = values.Value('mongodb://localhost:27017/girder')
+    ISIC_MONGO_URI = values.Value(None)
     # Allow developers to run tasks synchronously for easy debugging
     CELERY_TASK_ALWAYS_EAGER = values.BooleanValue(False)
     CELERY_TASK_EAGER_PROPAGATES = values.BooleanValue(False)


### PR DESCRIPTION
Typically, there's no MongoDB instance running in development, so the default setting value is not that useful. When Girder-integration is desired in development, just set the setting.