### PR TITLE
Remove _base_file_name test

### DIFF
--- a/isic/ingest/tests/test_zip_utils.py
+++ b/isic/ingest/tests/test_zip_utils.py
@@ -11,22 +11,6 @@ def zip_stream(data_dir):
         yield stream
 
 
-@pytest.mark.parametrize(
-    'path,expected',
-    [
-        ('', ''),
-        ('foo.txt', 'foo.txt'),
-        ('foo/bar.txt', 'bar.txt'),
-        ('foo/bar/baz', 'baz'),
-        ('foo\\bar.txt', 'bar.txt'),
-    ],
-    ids=['empty', 'root', 'nested', 'nested_2', 'windows'],
-)
-def test_base_file_name(path, expected):
-    file_name = zip_utils._base_file_name(path)
-    assert file_name == expected
-
-
 def test_file_names_in_zip(zip_stream):
     file_names = zip_utils.file_names_in_zip(zip_stream)
 


### PR DESCRIPTION
This is too much test complexity for the logic of the function itself.