### PR TITLE
Add script for staff and permissions

### DIFF
--- a/isic/core/management/commands/set_isic_permissions.py
+++ b/isic/core/management/commands/set_isic_permissions.py
@@ -1,0 +1,57 @@
+from django.contrib.auth.models import Group, Permission, User
+from django.contrib.contenttypes.models import ContentType
+import djclick as click
+
+from isic.core.models import DuplicateImage
+from isic.ingest.models import (
+    Accession,
+    CheckLog,
+    Cohort,
+    Contributor,
+    DistinctnessMeasure,
+    MetadataFile,
+    Zip,
+)
+from isic.studies.models import (
+    Annotation,
+    Feature,
+    Markup,
+    Question,
+    QuestionChoice,
+    Response,
+    Study,
+    StudyTask,
+)
+
+
+@click.command(help='Add ISIC Staff group with basic permissions')
+def add_staff_group():
+    group, _ = Group.objects.get_or_create(name='ISIC Staff')
+
+    for model in [
+        Accession,
+        Annotation,
+        CheckLog,
+        Cohort,
+        Contributor,
+        DistinctnessMeasure,
+        DuplicateImage,
+        Feature,
+        Markup,
+        MetadataFile,
+        Question,
+        QuestionChoice,
+        Response,
+        Study,
+        StudyTask,
+        User,
+        Zip,
+    ]:
+        content_type = ContentType.objects.get_for_model(model)
+        for permission in ['view', 'change']:
+            group.permissions.add(
+                Permission.objects.get(
+                    codename=f'{permission}_{content_type.model}',
+                    content_type=content_type,
+                )
+            )

--- a/isic/core/templates/core/base.html
+++ b/isic/core/templates/core/base.html
@@ -46,7 +46,7 @@
         </div>
 
         <!-- Admin Link -->
-        {% if request.user.is_superuser %}
+        {% if request.user.is_staff %}
         <div class="flex">
           <a href="{% url 'admin:index' %}" class="text-gray-900 inline-flex items-center px-1 text-sm font-medium">
             <i class="ri-admin-line mr-2 text-lg"></i>
@@ -57,9 +57,6 @@
         <div class="flex items-center px-4">
           <i class="ri-arrow-right-s-line text-gray-300"></i>
         </div>
-        {% endif %}
-
-        {% if request.user.is_staff %}
 
         <div class="flex">
           <a href="{% url 'staff-list' %}" class="text-gray-900 inline-flex items-center px-4 text-sm font-medium">


### PR DESCRIPTION
@brianhelba PTAL.

It kinda can't be done as a migration because the faux-models don't have the attributes necessary for `ContentType.objects.get_for_model`.