### PR TITLE
Rework Discourse SSO again, to just redirect to the login view

### DIFF
--- a/isic/discourse_sso/tests/conftest.py
+++ b/isic/discourse_sso/tests/conftest.py
@@ -39,18 +39,3 @@ def discourse_sso_credentials(settings):
 )
 def bad_discourse_sso_credentials(request):
     return request.param
-
-
-@pytest.fixture
-def valid_user(settings, user_factory):
-    """Provide a user who's ready to login."""
-    # Disable email verification, which will make a new user able to login
-    settings.ACCOUNT_EMAIL_VERIFICATION = 'none'
-    return user_factory(raw_password='testpassword')
-
-
-@pytest.fixture
-def invalid_user(user_factory):
-    """Provide a user who's not ready to login."""
-    # Email verification is already required, but new users will not have it
-    return user_factory(raw_password='testpassword')

--- a/isic/discourse_sso/tests/test_sso_view.py
+++ b/isic/discourse_sso/tests/test_sso_view.py
@@ -1,12 +1,10 @@
-import urllib.parse
-
 from django.urls import reverse
 import pytest
 
 
 @pytest.mark.django_db
 def test_sso_view_authenticated_success(authenticated_client, discourse_sso_credentials):
-    resp = authenticated_client.get(reverse('discourse-sso-login'), data=discourse_sso_credentials)
+    resp = authenticated_client.get(reverse('discourse-sso'), data=discourse_sso_credentials)
 
     assert resp.status_code == 302
     assert resp['Location'].startswith('https://a-return-url.com/session/sso_login')
@@ -16,52 +14,15 @@ def test_sso_view_authenticated_success(authenticated_client, discourse_sso_cred
 def test_sso_view_authenticated_failure(
     settings, authenticated_client, bad_discourse_sso_credentials
 ):
-    resp = authenticated_client.get(
-        reverse('discourse-sso-login'), data=bad_discourse_sso_credentials
-    )
+    resp = authenticated_client.get(reverse('discourse-sso'), data=bad_discourse_sso_credentials)
 
     assert resp.status_code == 302
     assert resp['Location'].startswith(settings.ISIC_DISCOURSE_SSO_FAIL_URL)
 
 
 @pytest.mark.django_db
-def test_sso_view_get(client, discourse_sso_credentials):
-    """Ensure the view works normally on GET."""
-    resp = client.get(reverse('discourse-sso-login'), data=discourse_sso_credentials)
-
-    assert resp.status_code == 200
-    assert 'form' in resp.context_data
-    assert not resp.context_data['form'].errors
-
-
-@pytest.mark.django_db
-def test_sso_view_post_success(client, discourse_sso_credentials, valid_user):
-    resp = client.post(
-        f'{reverse("discourse-sso-login")}?{urllib.parse.urlencode(discourse_sso_credentials)}',
-        {'login': valid_user.email, 'password': 'testpassword'},
-    )
+def test_sso_view_unauthenticated(client, discourse_sso_credentials):
+    resp = client.get(reverse('discourse-sso'), data=discourse_sso_credentials)
 
     assert resp.status_code == 302
-    assert resp['Location'].startswith('https://a-return-url.com/session/sso_login')
-
-
-@pytest.mark.django_db
-def test_sso_view_post_failure_user(client, discourse_sso_credentials, invalid_user):
-    resp = client.post(
-        f'{reverse("discourse-sso-login")}?{urllib.parse.urlencode(discourse_sso_credentials)}',
-        {'login': invalid_user.email, 'password': 'testpassword'},
-    )
-
-    assert resp.status_code == 302
-    assert resp['Location'] == '/accounts/confirm-email/'
-
-
-@pytest.mark.django_db
-def test_sso_view_post_failure_credentials(client, bad_discourse_sso_credentials, valid_user):
-    resp = client.post(
-        f'{reverse("discourse-sso-login")}?{urllib.parse.urlencode(bad_discourse_sso_credentials)}',
-        {'login': valid_user.email, 'password': 'testpassword'},
-    )
-
-    assert resp.status_code == 302
-    assert resp['Location'] == 'https://forum.isic-archive.com'
+    assert resp['Location'].startswith(reverse('account_login'))

--- a/isic/discourse_sso/urls.py
+++ b/isic/discourse_sso/urls.py
@@ -1,9 +1,5 @@
 from django.urls import path
 
-from isic.discourse_sso.views import DiscourseSsoLoginView
+from isic.discourse_sso.views import DiscourseSsoRedirectView
 
-urlpatterns = [
-    path(
-        'accounts/login/discourse-sso/', DiscourseSsoLoginView.as_view(), name='discourse-sso-login'
-    )
-]
+urlpatterns = [path('discourse-sso/', DiscourseSsoRedirectView.as_view(), name='discourse-sso')]

--- a/isic/discourse_sso/views.py
+++ b/isic/discourse_sso/views.py
@@ -1,47 +1,23 @@
-from allauth.account.views import LoginView
 from django.conf import settings
-from django.http.response import HttpResponseRedirectBase
-from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.http import urlencode
+from django.views.generic import RedirectView
 
 from isic.discourse_sso.utils import SSOException, _get_sso_parameters, _get_sso_redirect_url
 
 
-class DiscourseSsoLoginView(LoginView):
-    def _get_sso_redirect_url(self):
-        try:
-            sso_params = _get_sso_parameters(self.request)
-        except SSOException:
-            return settings.ISIC_DISCOURSE_SSO_FAIL_URL
+class DiscourseSsoRedirectView(RedirectView):
+    permanent = False
 
-        return _get_sso_redirect_url(self.request.user, sso_params)
-
-    def get_authenticated_redirect_url(self):
-        # Called when the user is already authenticated
-        return self._get_sso_redirect_url()
-
-    def get_success_url(self):
-        # Called when a form submission was successful, but before the user is actually logged in.
-        # The real redirect URL can't be known now, since it requires the user to construct.
-        # Return a sentinel value, so the login flow will proceed and construct a redirect to this
-        # "location".
-        # There are other reasons the login flow could fail and redirect to a different location
-        # (e.g. email validation required).
-        # Use ISIC_DISCOURSE_SSO_FAIL_URL as the sentinel in case something goes very wrong,
-        # so the redirect should send the user somewhere sane.
-        return settings.ISIC_DISCOURSE_SSO_FAIL_URL
-
-    def form_valid(self, form):
-        # Start the whole normal login flow
-        response = super().form_valid(form)
-
-        # Check if this made it through the login flow successfully and the response is primed
-        # to redirect the user to the sentinel value.
-        if (
-            self.request.user.is_authenticated
-            and isinstance(response, HttpResponseRedirectBase)
-            and response.url == settings.ISIC_DISCOURSE_SSO_FAIL_URL
-        ):
-            # Validate SSO and redirect to the actual appropriate location
-            response = redirect(self._get_sso_redirect_url(), permanent=False)
-
-        return response
+    def get_redirect_url(self, *args, **kwargs):
+        if self.request.user.is_authenticated:
+            try:
+                sso_params = _get_sso_parameters(self.request)
+            except SSOException:
+                return settings.ISIC_DISCOURSE_SSO_FAIL_URL
+            else:
+                return _get_sso_redirect_url(self.request.user, sso_params)
+        else:
+            current_url = self.request.get_full_path()
+            # Redirect to account_login, with a "next=" back to here
+            return f'{reverse("account_login")}?{urlencode({"next": current_url})}'

--- a/isic/settings.py
+++ b/isic/settings.py
@@ -27,10 +27,8 @@ class IsicMixin(ConfigMixin):
             'isic.login.apps.LoginConfig',
             'isic.ingest.apps.IngestConfig',
             'isic.studies.apps.StudiesConfig',
+            'isic.discourse_sso.apps.DiscourseSSOConfig',
         ] + configuration.INSTALLED_APPS
-
-        if configuration.ISIC_DISCOURSE_SSO_SECRET:
-            configuration.INSTALLED_APPS += ['isic.discourse_sso.apps.DiscourseSSOConfig']
 
         # Install additional apps
         configuration.INSTALLED_APPS += [
@@ -74,14 +72,7 @@ class IsicMixin(ConfigMixin):
         'allauth.account.auth_backends.AuthenticationBackend',
     ]
 
-    ISIC_DISCOURSE_SSO_SECRET = values.Value(
-        None,
-        # Don't bind late, so the value can be examined in before_binding
-        late_binding=False,
-        # Without late_binding, environ_name must be explicitly set for the setting to know its
-        # own name early enough
-        environ_name='ISIC_DISCOURSE_SSO_SECRET',
-    )
+    ISIC_DISCOURSE_SSO_SECRET = values.Value(None)
     ISIC_DISCOURSE_SSO_FAIL_URL = 'https://forum.isic-archive.com'
     ISIC_MONGO_URI = values.SecretValue()
 


### PR DESCRIPTION
With the previous design, SSO parameters were not included with in the login form submission.

This design is significantly simpler too.