### PR TITLE
Fix a reverse URL lookup in the study detail page

### DIFF
--- a/isic/studies/templates/studies/study_detail.html
+++ b/isic/studies/templates/studies/study_detail.html
@@ -40,7 +40,7 @@
     {% for annotation in annotations %}
       <tr>
         <td>{{ annotation.annotator  }}</td>
-        <td><a href="{% url 'core/image-detail' annotation.image.isic_id %}">{{ annotation.image.isic_id  }}</a></td>
+        <td><a href="{% url 'core/image-detail' annotation.image.pk %}">{{ annotation.image.isic_id  }}</a></td>
         <td>
           <a href="{{annotation.get_absolute_url}}">View Annotation</a>
         </td>


### PR DESCRIPTION
The `ImageIdentifierConverter.to_url` method (which this reverse lookup relies upon) expects a `pk`, not an `isic_id`.