### PR TITLE
Remove admin confirmation for ingest admin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
     install_requires=[
         'celery',
         'django',
-        'django-admin-confirm',
         'django-allauth',
         'django-configurations[database,email]',
         'django-extensions',


### PR DESCRIPTION
It's buggy for Django 4 and the actions we were using it for are now
supported in the GUI.