### PR TITLE
Add generic metadata application scripts

### DIFF
--- a/isic/ingest/management/commands/apply-metadata-files.py
+++ b/isic/ingest/management/commands/apply-metadata-files.py
@@ -1,0 +1,40 @@
+import sys
+
+from django.db import transaction
+import djclick as click
+from isic_metadata.metadata import MetadataRow
+
+from isic.ingest.models import Accession
+from isic.ingest.models.metadata_file import MetadataFile
+
+
+@click.command()
+@click.argument('metadata_file_id', nargs=-1, type=click.INT)
+def apply_metadata_files(metadata_file_id):
+    assert metadata_file_id
+    metadata_files = MetadataFile.objects.filter(pk__in=metadata_file_id)
+    missing_files = set(metadata_file_id) - set(metadata_files.values_list('pk', flat=True))
+
+    if missing_files:
+        click.secho(
+            f'Unable to find metadata files: {", ".join(map(str,missing_files))}',
+            fg='red',
+            err=True,
+        )
+        sys.exit(1)
+
+    for metadata_file in metadata_files:
+        with transaction.atomic():
+            for _, row in metadata_file.to_df().iterrows():
+                accession = Accession.objects.get(
+                    blob_name=row['filename'], cohort=metadata_file.cohort
+                )
+                # filename doesn't need to be stored in the metadata since it's equal to blob_name
+                del row['filename']
+                metadata = MetadataRow.parse_obj(row)
+                accession.unstructured_metadata.update(metadata.unstructured)
+                accession.metadata.update(
+                    metadata.dict(exclude_unset=True, exclude_none=True, exclude={'unstructured'})
+                )
+                accession.save(update_fields=['metadata', 'unstructured_metadata'])
+        click.secho(f'Applied metadata file: {metadata_file.pk}', fg='green')

--- a/isic/ingest/management/commands/metadata-files-from-csv.py
+++ b/isic/ingest/management/commands/metadata-files-from-csv.py
@@ -1,0 +1,54 @@
+import codecs
+from collections import defaultdict
+import csv
+import io
+
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+import djclick as click
+import numpy as np
+import pandas as pd
+
+from isic.ingest.models import Accession
+from isic.ingest.models.metadata_file import MetadataFile
+
+StreamWriter = codecs.getwriter('utf-8')
+
+
+@click.command()
+@click.argument('user_id', help='The user to attribute the metadata file to.')
+@click.argument('csv_path', help='The path to the CSV of metadata, containing an ISIC ID column.')
+@click.argument('isic_id_column', help='The name of the column that refers to the ISIC ID.')
+def metadata_files_from_csv(user_id, csv_path, isic_id_column):
+    u = User.objects.get(pk=user_id)
+    with open(csv_path) as f:
+        df = pd.read_csv(f, header=0)
+
+    # pydantic expects None for the absence of a value, not NaN
+    df = df.replace({np.nan: None})
+
+    cohort_files = defaultdict(list)
+
+    for _, (_, row) in enumerate(df.iterrows(), start=2):
+        accession: Accession = Accession.objects.select_related('cohort').get(
+            image__isic_id=row[isic_id_column]
+        )
+        del row[isic_id_column]
+        row['filename'] = accession.blob_name
+        cohort_files[accession.cohort.pk].append(dict(row))
+
+    for cohort_id, rows in cohort_files.items():
+        blob = StreamWriter(io.BytesIO())
+        w = csv.DictWriter(blob, list(set(list(df.columns)) - set('isic_id')) + ['filename'])
+        w.writeheader()
+        for row in rows:
+            w.writerow(row)
+        size = blob.tell()
+        blob.seek(0)
+        blob_name = f'cohort_{cohort_id}_metadata.csv'
+        blob = SimpleUploadedFile(blob_name, blob.getvalue(), 'text/csv')
+
+        m = MetadataFile.objects.create(
+            creator=u, cohort_id=cohort_id, blob=blob, blob_size=size, blob_name=blob_name
+        )
+        click.secho(f'Created metadata file: {m.pk}, authored by {u.email}', fg='green')


### PR DESCRIPTION
This is for applying metadata to images that already exist in the archive. See #486 and #487. 