### PR TITLE
publish creates locked collections

### DIFF
--- a/isic/core/services/collection/__init__.py
+++ b/isic/core/services/collection/__init__.py
@@ -20,9 +20,9 @@ def _require_unlocked_collection(collection: Collection) -> None:
         raise ValidationError("Can't modify the collection, it's locked.")
 
 
-def collection_create(*, creator: User, name: str, description: str, public: bool):
+def collection_create(*, creator: User, name: str, description: str, public: bool, locked: bool):
     return Collection.objects.create(
-        creator=creator, name=name, description=description, public=public
+        creator=creator, name=name, description=description, public=public, locked=locked
     )
 
 

--- a/isic/core/views/collections.py
+++ b/isic/core/views/collections.py
@@ -57,7 +57,9 @@ def collection_create_(request):
     if request.method == 'POST':
         context['form'] = CollectionForm(request.POST)
         if context['form'].is_valid():
-            collection = collection_create(creator=request.user, **context['form'].cleaned_data)
+            collection = collection_create(
+                creator=request.user, **context['form'].cleaned_data, locked=False
+            )
             return HttpResponseRedirect(reverse('core/collection-detail', args=[collection.pk]))
     else:
         context['form'] = CollectionForm()

--- a/isic/ingest/services/cohort/__init__.py
+++ b/isic/ingest/services/cohort/__init__.py
@@ -23,6 +23,7 @@ def cohort_publish_initialize(*, cohort: Cohort, publisher: User, public: bool) 
             name=f'Publish of {cohort.name}',
             description='',
             public=False,  # the collection is always private to avoid leaking cohort names
+            locked=True,
         )
         cohort.save(update_fields=['collection'])
 

--- a/isic/ingest/tests/test_publish.py
+++ b/isic/ingest/tests/test_publish.py
@@ -2,6 +2,7 @@ from django.urls.base import reverse
 from django.utils import timezone
 import pytest
 
+from isic.core.models.collection import Collection
 from isic.core.models.image import Image
 from isic.ingest.models.accession import AccessionStatus
 
@@ -34,3 +35,7 @@ def test_publish_cohort(staff_client, eager_celery, publishable_cohort):
 
     assert published_images.count() == 1
     assert not published_images.first().public
+    assert Collection.objects.count() == 1
+    magic_collection = Collection.objects.first()
+    assert not magic_collection.public
+    assert magic_collection.locked


### PR DESCRIPTION
- Hide quick find endpoint from swagger
- Ensure publishing creates a locked collection
