### PR TITLE
Notify Sentry about new releases prior to deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+
+name: release
+on:
+  push:
+    branches:
+      - master
+jobs:
+  sentry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: false
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: kitware-data
+          SENTRY_PROJECT: isic-api


### PR DESCRIPTION
This isn't required, but it gives Sentry a little more information.