### PR TITLE
Add zip streaming download

### DIFF
--- a/isic/core/templates/core/partials/image_browser_js.html
+++ b/isic/core/templates/core/partials/image_browser_js.html
@@ -39,6 +39,21 @@ function imageBrowser() {
     },
     copyIsicCliDownloadCommand() {
       navigator.clipboard.writeText(this.isicCliDownloadCommand());
+    },
+    downloadAsZip() {
+      const params = (new URL(document.location)).searchParams;
+
+      axios.post('/api/v2/zip-download/url/', Object.fromEntries(params), {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': '{{ csrf_token }}'
+        }
+      }).then((resp) => {
+        window.location.href = resp.data;
+      }).catch(function(error) {
+        alert('Something went wrong, try again.');
+        console.error(error);
+      });
     }
   }
 }

--- a/isic/core/templates/core/partials/image_gallery_actions.html
+++ b/isic/core/templates/core/partials/image_gallery_actions.html
@@ -12,6 +12,9 @@
     <div x-show="open" class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 divide-y divide-gray-100 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="menu-button" tabindex="-1">
       <div class="py-1" role="none">
         <a @click="modalOpen = true" href="#" class="hover:bg-gray-100 hover:text-gray-900 text-gray-700 block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="menu-item-0">Add results to collection</a>
+        {% if request.user.is_superuser %}
+          <a @click="downloadAsZip()" href="#" class="hover:bg-gray-100 hover:text-gray-900 text-gray-700 block px-4 py-2 text-sm" role="menuitem" tabindex="-1" id="menu-item-0">Download as ZIP</a>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/isic/settings.py
+++ b/isic/settings.py
@@ -191,6 +191,8 @@ class DevelopmentConfiguration(IsicMixin, DevelopmentBaseConfiguration):
     ISIC_DATACITE_DOI_PREFIX = '10.80222'
     MINIO_STORAGE_MEDIA_OBJECT_METADATA = {'Content-Disposition': 'attachment'}
 
+    ZIP_DOWNLOAD_SERVICE_URL = 'http://localhost:4008'
+
 
 class TestingConfiguration(IsicMixin, TestingBaseConfiguration):
     ISIC_ELASTICSEARCH_INDEX = 'isic-testing'
@@ -199,6 +201,7 @@ class TestingConfiguration(IsicMixin, TestingBaseConfiguration):
     CELERY_TASK_ALWAYS_EAGER = values.BooleanValue(False)
     CELERY_TASK_EAGER_PROPAGATES = values.BooleanValue(False)
     ISIC_DATACITE_DOI_PREFIX = '10.80222'
+    ZIP_DOWNLOAD_SERVICE_URL = 'http://service-url.test'
 
 
 class HerokuProductionConfiguration(IsicMixin, HerokuProductionBaseConfiguration):
@@ -213,3 +216,5 @@ class HerokuProductionConfiguration(IsicMixin, HerokuProductionBaseConfiguration
     AWS_S3_OBJECT_PARAMETERS = {'ContentDisposition': 'attachment'}
 
     SENTRY_TRACES_SAMPLE_RATE = 0.01  # sample 1% of requests for performance monitoring
+
+    ZIP_DOWNLOAD_SERVICE_URL = values.Value()

--- a/isic/urls.py
+++ b/isic/urls.py
@@ -56,6 +56,7 @@ urlpatterns = [
     path('', include('isic.ingest.urls')),
     path('', include('isic.stats.urls')),
     path('', include('isic.studies.urls')),
+    path('', include('isic.zip_download.urls')),
 ]
 
 if settings.DEBUG:

--- a/isic/zip_download/api.py
+++ b/isic/zip_download/api.py
@@ -1,0 +1,131 @@
+from collections import Counter
+import csv
+from datetime import timedelta
+from typing import Iterable
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.core.signing import BadSignature, TimestampSigner
+from django.http.response import HttpResponse, JsonResponse
+from django.urls.base import reverse
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import serializers
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from isic.core.models.image import Image
+from isic.core.serializers import SearchQuerySerializer
+from isic.core.services import _image_metadata_csv_headers, image_metadata_csv_rows
+from isic.zip_download.serializers import ZipFileDescriptorSerializer
+
+
+# this is directly mirrored in isic-cli
+def get_attributions(attributions: Iterable[str]) -> list[str]:
+    counter = Counter(attribution for attribution in attributions)
+    # sort by the number of images descending, then the name of the institution ascending
+    attributions = sorted(counter.most_common(), key=lambda v: (-v[1], v[0]))
+    # push anonymous attributions to the end
+    attributions = sorted(attributions, key=lambda v: 1 if v[0] == 'Anonymous' else 0)
+    return [x[0] for x in attributions]
+
+
+def get_zip_download_token(token: str | None = None) -> dict:
+    if not token:
+        raise PermissionDenied
+
+    signer = TimestampSigner()
+
+    try:
+        # TODO: do we sign tokens longer than URLs?
+        return signer.unsign_object(token, max_age=timedelta(days=1))
+    except BadSignature:
+        raise PermissionDenied
+
+
+@swagger_auto_schema(methods=['POST'], auto_schema=None)
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def create_zip_download_url(request):
+    serializer = SearchQuerySerializer(data=request.data, context={'user': request.user})
+    serializer.is_valid(raise_exception=True)
+
+    if serializer.to_queryset().count() > 1_000:
+        raise serializers.ValidationError(
+            'Only a maximum of 1,000 images can be downloaded per zip.'
+        )
+
+    token = TimestampSigner().sign_object(serializer.to_token_representation())
+
+    return Response(f'{settings.ZIP_DOWNLOAD_SERVICE_URL}/download?zsid={token}')
+
+
+@swagger_auto_schema(methods=['GET'], auto_schema=None)
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def zip_file_descriptor(request):
+    token = request.query_params.get('token')
+    download_info = get_zip_download_token(token)
+    serializer = SearchQuerySerializer.from_token_representation(download_info)
+    serializer.is_valid(raise_exception=True)
+
+    descriptor = {
+        'suggestedFilename': 'isic-data.zip',
+        'files': [
+            {
+                'url': f'http://{Site.objects.get_current().domain}'
+                + reverse('zip-download/api/metadata-file')
+                + f'?token={token}',
+                'zipPath': 'metadata.csv',
+            },
+            {
+                'url': f'http://{Site.objects.get_current().domain}'
+                + reverse('zip-download/api/attribution-file')
+                + f'?token={token}',
+                'zipPath': 'attribution.txt',
+            },
+        ],
+    }
+
+    qs = serializer.to_queryset(Image.objects.select_related('accession'))
+    for image in qs.iterator():
+        descriptor['files'].append(
+            {
+                'url': image.accession.blob.url,
+                'zipPath': f'{image.isic_id}.JPG',
+            }
+        )
+    return JsonResponse(ZipFileDescriptorSerializer(descriptor).data)
+
+
+@swagger_auto_schema(methods=['GET'], auto_schema=None)
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def zip_file_metadata_file(request):
+    download_info = get_zip_download_token(request.query_params.get('token'))
+    serializer = SearchQuerySerializer.from_token_representation(download_info)
+    serializer.is_valid(raise_exception=True)
+
+    qs = serializer.to_queryset(Image.objects.select_related('accession__cohort').distinct())
+    response = HttpResponse(content_type='text/csv')
+    writer = csv.DictWriter(response, _image_metadata_csv_headers(qs=qs))
+    writer.writeheader()
+
+    for metadata_row in image_metadata_csv_rows(qs=qs):
+        writer.writerow(metadata_row)
+
+    return response
+
+
+@swagger_auto_schema(methods=['GET'], auto_schema=None)
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def zip_file_attribution_file(request):
+    download_info = get_zip_download_token(request.query_params.get('token'))
+    serializer = SearchQuerySerializer.from_token_representation(download_info)
+    serializer.is_valid(raise_exception=True)
+
+    qs = serializer.to_queryset(Image.objects.select_related('accession__cohort').distinct())
+    attributions = get_attributions(qs.values_list('accession__cohort__attribution', flat=True))
+    return HttpResponse('\n\n'.join(attributions), content_type='text/plain')

--- a/isic/zip_download/apps.py
+++ b/isic/zip_download/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ZipDownloadConfig(AppConfig):
+    name = 'isic.zip_download'
+    verbose_name = 'ISIC: Zip Download'

--- a/isic/zip_download/serializers.py
+++ b/isic/zip_download/serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+
+
+class ZipFileFileDescriptorSerializer(serializers.Serializer):
+    url = serializers.URLField()
+    zipPath = serializers.CharField()  # noqa: N815
+
+
+# modeling https://github.com/scosman/zipstreamer#json-descriptor-a
+class ZipFileDescriptorSerializer(serializers.Serializer):
+    suggestedFilename = serializers.CharField()  # noqa: N815
+    files = ZipFileFileDescriptorSerializer(many=True)

--- a/isic/zip_download/tests/test_zip_download.py
+++ b/isic/zip_download/tests/test_zip_download.py
@@ -1,0 +1,26 @@
+from urllib.parse import parse_qs, urlparse
+
+from django.urls.base import reverse
+import pytest
+
+
+@pytest.fixture
+def random_images(image_factory):
+    image_factory(accession__metadata={'diagnosis': 'melanoma'}, public=True)
+    image_factory(accession__metadata={'diagnosis': 'nevus'}, public=True)
+
+
+@pytest.mark.django_db
+def test_zip_download(authenticated_api_client, random_images):
+    r = authenticated_api_client.post(
+        reverse('zip-download/api/url'), {'query': 'diagnosis:melanoma'}
+    )
+    assert r.status_code == 200, r.data
+    parsed_url = urlparse(r.data)
+    token = parse_qs(parsed_url.query)['zsid']
+    r = authenticated_api_client.get(
+        reverse('zip-download/api/file-descriptor'), data={'token': token[0]}
+    )
+    assert r.status_code == 200, r.json()
+    # 3 == metadata, attribution, and the matching melanoma image
+    assert len(r.json()['files']) == 3

--- a/isic/zip_download/urls.py
+++ b/isic/zip_download/urls.py
@@ -1,0 +1,31 @@
+from django.urls import path
+
+from isic.zip_download.api import (
+    create_zip_download_url,
+    zip_file_attribution_file,
+    zip_file_descriptor,
+    zip_file_metadata_file,
+)
+
+urlpatterns = [
+    path(
+        'api/v2/zip-download/url/',
+        create_zip_download_url,
+        name='zip-download/api/url',
+    ),
+    path(
+        'api/v2/zip-download/file-descriptor/',
+        zip_file_descriptor,
+        name='zip-download/api/file-descriptor',
+    ),
+    path(
+        'api/v2/zip-download/metadata-file/',
+        zip_file_metadata_file,
+        name='zip-download/api/metadata-file',
+    ),
+    path(
+        'api/v2/zip-download/attribution-file/',
+        zip_file_attribution_file,
+        name='zip-download/api/attribution-file',
+    ),
+]


### PR DESCRIPTION
Supersedes #436 

```mermaid
sequenceDiagram
    Client->>+API: Generate a signed URL for zip download
    API-->>-Client: Signed Zip Server URL
    Client->>+Zip Server: Request Zip with signed URL
    Zip Server->>+API: Ask for Zip File Descriptor
    API-->>-Zip Server: Zip file descriptor
    par 
        Zip Server->>+S3: Get image files     
    and
        Zip Server->>+API: Get metadata and attribution files
    end
    
    Zip Server-->>-Client: Send zip file
```