### PR TITLE
Start postgres in import-db script

### DIFF
--- a/dev/import-db.sh
+++ b/dev/import-db.sh
@@ -3,6 +3,8 @@ set -exuo pipefail
 
 export HEROKU_APP=isic
 
+docker-compose start postgres
+
 docker-compose exec postgres bash -c "PGPASSWORD=postgres dropdb --host localhost --username postgres --if-exists django && createdb --host localhost --username postgres django"
 
 # public.stats_imagedownload is large and not usually needed


### PR DESCRIPTION
I couldn't get this working with the whole docker-compose being up, and it also doesn't work if it's fully down. This command is idempotent, so it won't hurt either way.