### PR TITLE
Pin pandas to < 2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "more_itertools",
         "oauth2client",
         "opensearch-py",
-        "pandas",
+        "pandas<2.1.0",
         "passlib[bcrypt]",
         "Pillow",
         "pycountry",


### PR DESCRIPTION
New release of pandas broke some access log parsing, pin it for the immediate moment.