### PR TITLE
Allow Ninja to enforce CSRF on a per-auth method basis

### DIFF
--- a/isic/middleware.py
+++ b/isic/middleware.py
@@ -1,25 +1,8 @@
 import logging
 
-from ninja.operation import PathView
 from sentry_sdk import set_tag
 
 logger = logging.getLogger(__name__)
-
-
-# See https://github.com/vitalik/django-ninja/issues/283.
-# This exists to allow the header based authentication to be exempt from CSRF checks,
-# while still enforcing CSRF checks on the session based authentication.
-class ExemptBearerAuthFromCSRFMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        return self.get_response(request)
-
-    def process_view(self, request, view_func, view_args, view_kwargs):
-        klass = getattr(view_func, "__self__", None)
-        if klass and isinstance(klass, PathView):
-            request._dont_enforce_csrf_checks = True  # noqa: SLF001
 
 
 class UserTypeTagMiddleware:

--- a/isic/settings/base.py
+++ b/isic/settings/base.py
@@ -127,8 +127,6 @@ MIDDLEWARE = [
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    # Insert the ExemptBearerAuthFromCSRFMiddleware just before the CsrfViewMiddleware
-    "isic.middleware.ExemptBearerAuthFromCSRFMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",

--- a/isic/urls.py
+++ b/isic/urls.py
@@ -36,7 +36,6 @@ api = NinjaAPI(
     version="v2",
     docs_url=None,  # we want to serve the docs next to the ninja root rather than under it
     auth=allow_any,
-    csrf=True,
     urls_namespace="api",
 )
 swagger_view = partial(openapi_view, api=api)


### PR DESCRIPTION
Globally enabling CSRF is no longer necessary, as newer versions of Ninja will now directly enforce it for any cookie auth. So, we can also remove the global disable `ExemptBearerAuthFromCSRFMiddleware`, since auth via bearer won't check CSRF (which is correct).