### PR TITLE
Stop using signed URLs for zipstreamer

### DIFF
--- a/isic/core/storages/s3.py
+++ b/isic/core/storages/s3.py
@@ -42,5 +42,7 @@ class CacheableCloudFrontStorage(PreventRenamingMixin, S3Storage):
             return url
 
 
-class PreventRenamingS3StaticStorage(PreventRenamingMixin, S3StaticStorage):
-    pass
+class IsicS3StaticStorage(PreventRenamingMixin, S3StaticStorage):
+    def unsigned_url(self, name: str) -> str:
+        name = self._normalize_name(clean_name(name))
+        return f"https://{self.bucket_name}.s3.{self.region_name}.amazonaws.com/{name}"

--- a/isic/settings/base.py
+++ b/isic/settings/base.py
@@ -270,8 +270,6 @@ ISIC_GOOGLE_ANALYTICS_PROPERTY_IDS = [
 ISIC_ZIP_DOWNLOAD_SERVICE_URL: ParseResult | None = env.url(
     "DJANGO_ISIC_ZIP_DOWNLOAD_SERVICE_URL", default=None
 )
-# Requires CloudFront configuration
-ISIC_ZIP_DOWNLOAD_WILDCARD_URLS = True
 
 ISIC_CDN_LOG_BUCKET: str | None = env.str("DJANGO_ISIC_CDN_LOG_BUCKET", default=None)
 

--- a/isic/settings/development.py
+++ b/isic/settings/development.py
@@ -51,12 +51,12 @@ INTERNAL_IPS = InternalIPS(env.list("DJANGO_INTERNAL_IPS", cast=str, default=["1
 STORAGES.update(
     {
         "default": {
-            "BACKEND": "isic.core.storages.minio.PreventRenamingMinioMediaStorage",
+            "BACKEND": "isic.core.storages.minio.IsicMinioMediaStorage",
         },
         "sponsored": {
             # Using a "MediaStorage" will reuse most of the settings for the default storage
             # (auto-detected from env vars), but we override some distinct options.
-            "BACKEND": "isic.core.storages.minio.PreventRenamingMinioMediaStorage",
+            "BACKEND": "isic.core.storages.minio.IsicMinioMediaStorage",
             "OPTIONS": {
                 "bucket_name": cast(str, env.str("DJANGO_ISIC_SPONSORED_BUCKET_NAME")),
                 "base_url": cast(
@@ -94,7 +94,6 @@ CACHALOT_TIMEOUT = 0
 # In development, always present the approval dialog
 OAUTH2_PROVIDER["REQUEST_APPROVAL_PROMPT"] = "force"
 
-ISIC_ZIP_DOWNLOAD_WILDCARD_URLS = False
 
 # suppress noisy cache invalidation log messages
 logging.getLogger("isic.core.signals").setLevel(logging.ERROR)

--- a/isic/settings/testing.py
+++ b/isic/settings/testing.py
@@ -36,10 +36,10 @@ isic_sponsored_base_url = (
 STORAGES.update(
     {
         "default": {
-            "BACKEND": "isic.core.storages.minio.PreventRenamingMinioMediaStorage",
+            "BACKEND": "isic.core.storages.minio.IsicMinioMediaStorage",
         },
         "sponsored": {
-            "BACKEND": "isic.core.storages.minio.PreventRenamingMinioMediaStorage",
+            "BACKEND": "isic.core.storages.minio.IsicMinioMediaStorage",
             "OPTIONS": {
                 "bucket_name": isic_sponsored_bucket_name,
                 "base_url": isic_sponsored_base_url,
@@ -62,7 +62,6 @@ ISIC_ELASTICSEARCH_IMAGES_INDEX = "test-isic-images"
 ISIC_ELASTICSEARCH_LESIONS_INDEX = "test-isic-lesions"
 ISIC_USE_ELASTICSEARCH_COUNTS = False
 
-ISIC_ZIP_DOWNLOAD_WILDCARD_URLS = False
 
 # suppress noisy cache invalidation log messages
 logging.getLogger("isic.core.signals").setLevel(logging.ERROR)


### PR DESCRIPTION
This should greatly improve dev/prod parity by no longer requiring a
CloudFrontSigner for generating zip bundles. The one downside is that
private images will no longer be able to accessed through cloudfront.

This has no implications on security since the endpoint can only return
URLs that the signed token allows for anyway.

depends on https://github.com/ImageMarkup/isic-infrastructure/pull/377