### PR TITLE
Only run semgrep on the `isic/` directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ dependency_groups =
 commands =
     ruff check
     ruff format --check
-    semgrep scan --quiet --config rules.yml --error
+    semgrep scan --quiet --config rules.yml --error ./isic
     djhtml --check ./isic
 
 [testenv:format]


### PR DESCRIPTION
Otherwise, semgrep is scanning `.tox/` (and maybe other ignored locations).