### PR TITLE
Prevent hashid collisions using a consistent alphabet

### DIFF
--- a/isic/login/models.py
+++ b/isic/login/models.py
@@ -20,7 +20,9 @@ def get_hashid_hasher():
     # Note: changing the alphabet necessitates changing HASH_ID_REGEX
     return Hashids(
         min_length=5,
-        alphabet=list(set(string.ascii_uppercase + string.digits) - {"I", "1", "O", "0"}),
+        # hashids must have alphabet passed in a consistent order otherwise
+        # different invocations of the hasher will produce different results for the same input.
+        alphabet=sorted(set(string.ascii_uppercase + string.digits) - {"I", "1", "O", "0"}),
     )
 
 


### PR DESCRIPTION
Different invocations of python provide differently ordered alphabets since set order is undefined. This causes the hasher to produce identical hashids for different inputs, leading to collisions in production.