### PR TITLE
Move IPTC processing to before image unembargo

### DIFF
--- a/isic/core/services/image/__init__.py
+++ b/isic/core/services/image/__init__.py
@@ -9,11 +9,16 @@ from isic.ingest.models.accession import Accession
 
 
 def image_create(*, creator: User, accession: Accession, public: bool) -> Image:
+    from isic.core.services.iptc import embed_iptc_metadata_for_image
+
     with transaction.atomic():
         isic_id = IsicId.objects.create_random()
         image = Image(isic=isic_id, creator=creator, accession=accession, public=public)
         image.full_clean()
         image.save()
+
+        embed_iptc_metadata_for_image(image)
+
         return image
 
 

--- a/isic/core/services/iptc.py
+++ b/isic/core/services/iptc.py
@@ -1,0 +1,39 @@
+from django.core.files import File
+
+from isic.core.models.image import Image
+from isic.ingest.services.publish import embed_iptc_metadata
+
+
+def embed_iptc_metadata_for_image(image: Image, *, ignore_public_check=False) -> None:
+    # this is designed to embed IPTC metadata in the image before unembargoing
+    if not ignore_public_check and image.public:
+        raise ValueError("Cannot embed IPTC metadata for public images.")
+
+    accession = image.accession
+    attribution = accession.attribution
+    copyright_license = accession.copyright_license
+    isic_id = image.isic_id
+
+    with (
+        embed_iptc_metadata(
+            accession.blob,
+            attribution,
+            copyright_license,
+            isic_id,
+        ) as blob_with_iptc,
+        embed_iptc_metadata(
+            accession.thumbnail_256,
+            attribution,
+            copyright_license,
+            isic_id,
+        ) as thumbnail_with_iptc,
+    ):
+        accession.blob = File(
+            blob_with_iptc,
+            name=f"{isic_id}.{accession.extension}",
+        )
+        accession.thumbnail_256 = File(
+            thumbnail_with_iptc,
+            name=f"{isic_id}_thumbnail.jpg",
+        )
+        accession.save(update_fields=["blob", "thumbnail_256"])

--- a/isic/ingest/services/publish/__init__.py
+++ b/isic/ingest/services/publish/__init__.py
@@ -176,22 +176,11 @@ def embed_iptc_metadata(
 def unembargo_image(*, image: Image) -> None:
     storage_keys_to_delete = []
 
-    attribution = image.accession.attribution
-    copyright_license = image.accession.copyright_license
-
     with (
-        embed_iptc_metadata(
-            image.accession.blob,  # nosem: use-image-blob-where-possible
-            attribution,
-            copyright_license,
-            image.isic_id,
-        ) as sponsored_blob,
-        embed_iptc_metadata(
-            image.accession.thumbnail_256,  # nosem: use-image-thumbnail-256-where-possible
-            attribution,
-            copyright_license,
-            image.isic_id,
-        ) as sponsored_thumbnail_256_blob,
+        image.accession.blob.open("rb") as blob_file,  # nosem: use-image-blob-where-possible
+        image.accession.thumbnail_256.open(  # nosem: use-image-thumbnail-256-where-possible
+            "rb"
+        ) as thumbnail_file,
     ):
         storage_keys_to_delete.append(
             image.accession.blob.name  # nosem: use-image-blob-where-possible
@@ -205,12 +194,12 @@ def unembargo_image(*, image: Image) -> None:
             # the blob based on image.public. in the event of reprocessing an accession that's
             # already public, image.extension would try to reach into the sponsored_blob which
             # won't exist.
-            sponsored_blob,
+            blob_file,
             name=f"{image.isic_id}.{image.accession.extension}",
         )
         # nosem: use-image-thumbnail-256-where-possible
         image.accession.sponsored_thumbnail_256_blob = File(
-            sponsored_thumbnail_256_blob,
+            thumbnail_file,
             name=f"{image.isic_id}_thumbnail.jpg",
         )
         image.accession.blob = ""  # nosem: use-image-blob-where-possible


### PR DESCRIPTION
This is in preparation for draft DOIs. From now on IPTC metadata will be
embedded in all images once they're promoted from accessions, regardless
of their public status.
