### PR TITLE
Use TOX_WORK_DIR for storing tox outside of the project root

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -8,14 +8,6 @@ RUN mv /root/.local/bin/uvx /usr/local/bin/uvx
 ENV PYTHONDONTWRITEBYTECODE=1 \
   PYTHONUNBUFFERED=1
 
-# Make uv install content in well-known locations
-ENV UV_PROJECT_ENVIRONMENT=/var/lib/venv \
-  UV_CACHE_DIR=/var/cache/uv/cache \
-  UV_PYTHON_INSTALL_DIR=/var/cache/uv/bin \
-  # The uv cache and environment are expected to be mounted on different volumes,
-  # so hardlinks won't work
-  UV_LINK_MODE=symlink
-
 # Install system librarires for Python packages.
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,6 +17,7 @@ services:
       UV_CACHE_DIR: /home/vscode/uv/cache
       UV_PYTHON_INSTALL_DIR: /home/vscode/uv/bin
       UV_LINK_MODE: symlink
+      TOX_WORK_DIR: /home/vscode/tox
     working_dir: /home/vscode/isic
     env_file: ./dev/.env.docker-compose
     volumes:
@@ -58,6 +59,7 @@ services:
       UV_CACHE_DIR: /home/vscode/uv/cache
       UV_PYTHON_INSTALL_DIR: /home/vscode/uv/bin
       UV_LINK_MODE: symlink
+      TOX_WORK_DIR: /home/vscode/tox
     working_dir: /home/vscode/isic
     volumes:
       - .:/home/vscode/isic
@@ -94,6 +96,7 @@ services:
       UV_CACHE_DIR: /home/vscode/uv/cache
       UV_PYTHON_INSTALL_DIR: /home/vscode/uv/bin
       UV_LINK_MODE: symlink
+      TOX_WORK_DIR: /home/vscode/tox
     working_dir: /home/vscode/isic
     volumes:
       - .:/home/vscode/isic


### PR DESCRIPTION
The initial motivation for this is a bug in cursor that causes finding
devcontainer.json take a very long time with the typical .tox directory
containing tens of thousands of orphaned (from the host's perspective)
symlinks.
