### PR TITLE
Pin RabbitMQ to a version compatible with Celery defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         ports:
           - 9200:9200
       rabbitmq:
-        image: rabbitmq:management-alpine
+        image: rabbitmq:4.2-management-alpine
         options: >-
           --health-cmd "rabbitmq-diagnostics ping"
           --health-start-period 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - elasticsearch:/usr/share/elasticsearch/data
 
   rabbitmq:
-    image: rabbitmq:management-alpine
+    image: rabbitmq:4.2-management-alpine
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       start_period: 30s


### PR DESCRIPTION
See https://github.com/kitware-resonant/cookiecutter-resonant/pull/484
