### PR TITLE
Fix `.git-blame-ignore-revs` references

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,16 +13,16 @@ b086108f04296e2a23c6943fb81cc5d158923cfd
 # apply ruff upgrade fixes
 6ea87d33dd55e9164986d8054e22b1a7af1f5b17
 # normalize ingest URL names to module/name prefix convention
-d3c87e52ef79391842bbf17192df88111b610a6e
+ad950bc7f064008f9f0fd281d89dda1aea51ba3d
 # rename StudyTaskSet to StudyTaskQuerySet
-1a32c0552b06f32cec40807161a4bc9714cbfc72
+97253da2805037365c44e0704c321bfdd3f918c6
 # add generic type parameters to QuerySet subclasses
-ec2e76d048f9359813951e350de695c561200ea9
+e3291b85c8e21ec024cd350e879938abd5f85959
 # convert ingest and studies urls.py to explicit from-imports
-fe4073bb25eb93f93e9246f6c7bf6a39baf0a46b
+9b994c0cf5b67fe998ee083067212595e872c1fc
 # rename service functions to verb-noun and unify import style
-fdd2bcfba2acd260decd89d2e253ecac2beb2ce0
+a6d44f367da3cd2c6bee428c69d3ce156058dd7c
 # enforce _task suffix on Celery tasks and fix violations
-4af6387ce3254bf2ce398086cfcc8bda93e5dea0
+17838acc51c4f0bd24c6a336ce971519b38a816f
 # fix remaining noun-verb ordering in service and view names
-6c2d90e41153f2cb65b842ee81a77cb28cec833d
+90af2cb60c1972284e9afcfb3d38282b4150ef02


### PR DESCRIPTION
These were referencing a broken version of Git history. Fix them to reference the current (correct) history.