### PR TITLE
Fix `DJANGO_MINIO_STORAGE_MEDIA_URL`

### DIFF
--- a/dev/.env.docker-compose
+++ b/dev/.env.docker-compose
@@ -3,7 +3,9 @@ DJANGO_DATABASE_URL=postgres://postgres:postgres@postgres:5432/django
 DJANGO_ISIC_ELASTICSEARCH_URL=http://elastic:elastic@elasticsearch:9200
 DJANGO_CELERY_BROKER_URL=amqp://rabbitmq:5672/
 DJANGO_MINIO_STORAGE_URL=http://minioAccessKey:minioSecretKey@minio:9000/django-storage
+DJANGO_MINIO_STORAGE_MEDIA_URL=http://localhost:9000/django-storage
 DJANGO_ISIC_SPONSORED_BUCKET_NAME=django-sponsored
+DJANGO_ISIC_SPONSORED_MEDIA_URL=http://localhost:9000/django-sponsored
 DJANGO_CACHE_URL=redis://redis:6379/0
 DJANGO_ISIC_ZIP_DOWNLOAD_SERVICE_URL=http://zipstreamer:4008
 # When in Docker, the bridge network sends requests from the host machine exclusively via a


### PR DESCRIPTION
This was removed in #1403 and not restored by #1452.