### PR TITLE
Show created dates for ignored accessions

### DIFF
--- a/isic/ingest/templates/ingest/cohort_detail.html
+++ b/isic/ingest/templates/ingest/cohort_detail.html
@@ -31,22 +31,42 @@
       {% include 'studies/partials/pagination.html' with page_obj=accessions %}
     </div>
 
-    <div class="mb-4">
-      <div class="bg-white border rounded-lg">
-        <div class="px-4 py-3 border-b bg-gray-50">
-          <h4 class="font-medium text-gray-900">Original Filenames</h4>
-        </div>
-        <div class="p-4">
-          {% if show_skipped %}
-            <ul class="space-y-1 text-sm font-mono">
-              {% for accession in accessions %}
-                <li class="text-gray-700">{{ accession.original_blob_name }}</li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="text-gray-500 italic">No ignored accessions found.</p>
-          {% endif %}
-        </div>
+    <div class="overflow-x-auto">
+      <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+        <table class="w-full table-fixed divide-y divide-gray-200">
+          <colgroup>
+            <col class="hidden sm:table-column" style="width: 15%">
+            <col class="hidden sm:table-column" style="width: 85%">
+          </colgroup>
+          <thead class="bg-gray-50">
+            <tr>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                Created
+              </th>
+              <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                Original Filename
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for accession in accessions %}
+              <tr class="{% cycle 'bg-white' 'bg-gray-50' %}">
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {{ accession.created|date:"Y-m-d" }}
+                </td>
+                <td class="px-6 py-4 text-sm font-medium text-gray-700 overflow-hidden">
+                  <span class="truncate min-w-0">{{ accession.original_blob_name }}</span>
+                </td>
+              </tr>
+            {% empty %}
+              <tr>
+                <td colspan="4" class="px-6 py-4 text-sm text-gray-500 text-center">
+                  No ignored accessions found.
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
   {% else %}


### PR DESCRIPTION
This PR updates the template for the cohort detail page, specifically the section showing ignored accessions. Rather than displaying ignored accessions as a list with only the original filenames, this PR updates that view to display a table with the created dates alongside the original filenames. The table matches the style of the collections table.

<img width="1012" height="401" alt="image" src="https://github.com/user-attachments/assets/286c52ac-660d-4de7-896c-814e49c21bf7" />

When no ignored accessions exist, the table looks like this:
<img width="1011" height="297" alt="image" src="https://github.com/user-attachments/assets/45404654-af94-4633-8c41-77b65a6f7b9c" />
