### PR TITLE
Convert `.then`s to `async/await`s

### DIFF
--- a/isic/core/templates/core/base.html
+++ b/isic/core/templates/core/base.html
@@ -81,21 +81,20 @@
     </script>
 
     <script type="text/javascript">
-      function downloadAsZip(params) {
+      async function downloadAsZip(params) {
         params = params || Object.fromEntries((new URL(document.location)).searchParams);
-        console.log(params);
-
-        axios.post('/api/v2/zip-download/url/', params, {
-          headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': '{{ csrf_token }}'
-          }
-        }).then((resp) => {
+        try {
+          const resp = await axios.post('/api/v2/zip-download/url/', params, {
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRFToken': '{{ csrf_token }}'
+            }
+          });
           window.location.href = resp.data;
-        }).catch(function(error) {
+        } catch (error) {
           alert('Something went wrong, try again.');
-          console.error(error);
-        });
+          throw error;
+        }
       }
     </script>
 

--- a/isic/core/templates/core/collection_detail.html
+++ b/isic/core/templates/core/collection_detail.html
@@ -196,7 +196,7 @@
     function collectionDetail() {
       return {
         errorMessage: '',
-        shareCollectionWithUsers() {
+        async shareCollectionWithUsers() {
           let _this = this; // eek
 
           if ($('#user-selection').val().length === 0) {
@@ -205,52 +205,51 @@
           }
 
           if (confirm('Are you sure you want to grant additional access to this collection?')) {
-            axios.post('{% url "api:collection_share_to_users" collection.pk %}', {
-              user_ids: $('#user-selection').val().map(function(n) { return parseInt(n) }),
-              notify: document.getElementById('notify-users').checked
-            }, {
+            try {
+              const resp = await axios.post('{% url "api:collection_share_to_users" collection.pk %}', {
+                user_ids: $('#user-selection').val().map(function(n) { return parseInt(n) }),
+                notify: document.getElementById('notify-users').checked
+              }, {
+                headers: {
+                  'Content-Type': 'application/json',
+                  'X-CSRFToken': '{{ csrf_token }}'
+                }
+              });
+              window.location.reload();
+            } catch (error) {
+              _this.errorMessage = error.response.data[0];
+              alert('Something went wrong, try again.');
+              throw error;
+            }
+          }
+        },
+        async setPinned(pinned) {
+          try {
+            const resp = await axios.post('/api/v2/collections/{{ collection.pk }}/set-pinned/', { pinned }, {
               headers: {
                 'Content-Type': 'application/json',
                 'X-CSRFToken': '{{ csrf_token }}'
               }
-            }).then((resp) => {
-              window.location.reload();
-            }).catch(function(error) {
-              _this.errorMessage = error.response.data[0];
             });
+            window.location.reload();
+          } catch (error) {
+            alert('Something went wrong, try again.');
+            throw error;
           }
         },
-        setPinned(pinned) {
-          axios.post('/api/v2/collections/{{ collection.pk }}/set-pinned/', { pinned }, {
-            headers: {
-              'Content-Type': 'application/json',
-              'X-CSRFToken': '{{ csrf_token }}'
-            }
-          }).then(() => {
-            window.location.reload();
-          }).catch(function(error) {
-            if (error.response && error.response.data && error.response.data.error) {
-              alert(error.response.data.error);
-            } else {
-              alert('Something went wrong.');
-            }
-          });
-        },
-        deleteCollection() {
+        async deleteCollection() {
           if (confirm('Are you sure you want to delete this collection? This action cannot be undone.')) {
-            axios.delete('/api/v2/collections/{{ collection.pk }}/', {
-              headers: {
-                'X-CSRFToken': '{{ csrf_token }}'
-              }
-            }).then((resp) => {
+            try {
+              const resp = await axios.delete('/api/v2/collections/{{ collection.pk }}/', {
+                headers: {
+                  'X-CSRFToken': '{{ csrf_token }}'
+                }
+              });
               window.location.href = '{% url "core/collection-list" %}';
-            }).catch(function(error) {
-              if (error.response && error.response.data && error.response.data.error) {
-                alert(error.response.data.error);
-              } else {
-                alert('Something went wrong.');
-              }
-            });
+            } catch (error) {
+              alert('Something went wrong, try again.');
+              throw error;
+            }
           }
         },
       };
@@ -261,14 +260,18 @@
         attributions: [],
         fetched: false,
         loading: false,
-        fetchMetaInformation() {
+        async fetchMetaInformation() {
           const _this = this;
           this.loading = true;
-          axios.get('{% url "api:collection_attribution_information" collection.pk %}').then((resp) => {
+          try {
+            const resp = await axios.get('{% url "api:collection_attribution_information" collection.pk %}');
             _this.attributions = resp.data;
             _this.loading = false;
             _this.fetched = true;
-          });
+          } catch (error) {
+            alert('Something went wrong, try again.');
+            throw error;
+          }
         }
       }
     }

--- a/isic/core/templates/core/partials/edit_collection_js.html
+++ b/isic/core/templates/core/partials/edit_collection_js.html
@@ -29,20 +29,24 @@
       removeImage(imageId) {
         this._persist();
       },
-      deleteImages() {
+      async deleteImages() {
         let _this = this; // eek
         if (confirm(`Are you sure you want to remove ${this.images.size} images from this collection?`)) {
-          axios.post(`/api/v2/collections/${this.collectionId}/remove-from-list/`, {'isic_ids': this._imagesToArray()},
-            { headers: {
-              'Content-Type': 'application/json',
-              'X-CSRFToken': '{{ csrf_token }}'
-            }
-            }).then((resp) => {
-              this.resetImages(`/collections/${this.collectionId}/`);
-            }).catch(function(error) {
-              console.error(error);
-              alert('Something went wrong.');
-            });
+          try {
+            const resp = await axios.post(`/api/v2/collections/${this.collectionId}/remove-from-list/`,
+              {'isic_ids': this._imagesToArray()},
+              {
+                headers: {
+                  'Content-Type': 'application/json',
+                  'X-CSRFToken': '{{ csrf_token }}'
+                }
+              }
+            );
+            this.resetImages(`/collections/${this.collectionId}/`);
+          } catch (error) {
+            alert('Something went wrong, try again.');
+            throw error;
+          }
         }
       },
       resetImages(url) {

--- a/isic/core/templates/core/partials/image_browser_js.html
+++ b/isic/core/templates/core/partials/image_browser_js.html
@@ -13,19 +13,25 @@
           this.addSearchResultsToCollection();
         });
       },
-      addSearchResultsToCollection() {
+      async addSearchResultsToCollection() {
         let _this = this;
         if (confirm('Are you sure you want to add {{ total_images|intcomma }} images to this collection?')) {
-          axios.post(`/api/v2/collections/${this.selectedCollection}/populate-from-search/`, '{{ search_body|escapejs }}', {
-            headers: {
-              'Content-Type': 'application/json',
-              'X-CSRFToken': '{{ csrf_token }}'
-            }
-          }).then((resp) => {
+          try {
+            const resp = await axios.post(
+              `/api/v2/collections/${this.selectedCollection}/populate-from-search/`,
+              '{{ search_body|escapejs }}',
+              {
+                headers: {
+                  'Content-Type': 'application/json',
+                  'X-CSRFToken': '{{ csrf_token }}'
+                }
+              },
+            );
             window.location.href = `/collections/${this.selectedCollection}/`;
-          }).catch(function(error) {
-            _this.errorMessage = error.response.data[0];
-          });
+          } catch (error) {
+            alert('Something went wrong, try again.');
+            throw error;
+          }
         } else {
           this.selectedCollection = '';
         }

--- a/isic/ingest/templates/ingest/metadata_apply.html
+++ b/isic/ingest/templates/ingest/metadata_apply.html
@@ -22,25 +22,23 @@
   </div>
 
   <script type="text/javascript">
-    function deleteMetadataFile(pk, e) {
+    async function deleteMetadataFile(pk, e) {
       e.preventDefault();
 
       if (confirm('Are you sure you want to delete this file?')) {
-        fetch(`/api/v2/metadata-files/${pk}/`, {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-CSRFToken': '{{ csrf_token }}'
-          },
-        }).then((resp) => {
-          if (!resp.ok) {
-            throw new Error('Something went wrong.');
-          }
-
+        try {
+          const resp = await fetch(`/api/v2/metadata-files/${pk}/`, {
+            method: 'DELETE',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-CSRFToken': '{{ csrf_token }}'
+            },
+          });
           window.location.reload();
-        }).catch((error) => {
-          alert('There was a problem deleting the file.');
-        });
+        } catch (error) {
+          alert('Something went wrong, try again.');
+          throw error;
+        }
       }
     }
   </script>

--- a/isic/ingest/templates/ingest/metadata_file_detail.html
+++ b/isic/ingest/templates/ingest/metadata_file_detail.html
@@ -21,29 +21,28 @@ not for templates rendered with render_to_string.
       return {
         applying: false,
         applied: false,
-        apply() {
+        async apply() {
           this.applying = true;
-
-          fetch(`/api/v2/metadata-files/{{ metadata_file.id }}/update_metadata/`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-CSRFToken': '{{ csrf_token }}'
-            },
-            body: JSON.stringify({})
-          }).then((resp) => {
+          try {
+            const resp = await fetch(`/api/v2/metadata-files/{{ metadata_file.id }}/update_metadata/`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': '{{ csrf_token }}'
+              },
+              body: JSON.stringify({})
+            });
             if (!resp.ok) {
               throw new Error('Something went wrong.');
             }
-
             this.applied = true;
             this.applying = false;
             window.location.href = '{% url "ingest/cohort-detail" cohort.id %}';
-          }).catch((err) => {
+          } catch (error) {
             this.applying = false;
-            console.error(err);
-            alert('Something went wrong.');
-          });
+            alert('Something went wrong, try again.');
+            throw error;
+          }
         }
       }
     }

--- a/isic/stats/templates/stats/stats.html
+++ b/isic/stats/templates/stats/stats.html
@@ -34,56 +34,62 @@
   {{ 30_day_sessions_per_country|json_script:"country_data" }}
 
   <script type="text/javascript">
-    const country_values = JSON.parse(document.getElementById("country_data").textContent);
-
-    fetch('https://unpkg.com/world-atlas/countries-110m.json').then((r) => r.json()).then((data) => {
-      const countries = ChartGeo.topojson.feature(data, data.objects.countries).features;
-
-      const chart = new Chart(document.getElementById("canvas").getContext("2d"), {
-        type: 'choropleth',
-        data: {
-          labels: countries.map((d) => d.properties.name),
-          datasets: [{
-            label: 'Countries',
-            data: countries.map((d) => {
-              const country = country_values.filter(x => x.country_numeric === d.id)[0];
-              if (country === undefined) {
-                return {feature: d, value: 0};
-              } else {
-                return {feature: d, value: Math.log(country.sessions)};
-              }
-            }),
-          }]
-        },
-        options: {
-          showOutline: true,
-          showGraticule: false,
-          plugins: {
-            tooltip: {
-              callbacks: {
-                label(item) {
-                  if (item.raw.value === 0) {
-                    return `${item.chart.data.labels[item.dataIndex]}: 0`;
-                  } else {
-                    return `${item.chart.data.labels[item.dataIndex]}: ${Math.ceil(Math.exp(item.raw.value))}`;
-                  }
+    async function initChart() {
+      const country_values = JSON.parse(document.getElementById("country_data").textContent);
+      try {
+        const resp = await fetch('https://unpkg.com/world-atlas/countries-110m.json');
+        const data = await resp.json();
+        const countries = ChartGeo.topojson.feature(data, data.objects.countries).features;
+        const chart = new Chart(document.getElementById("canvas").getContext("2d"), {
+          type: 'choropleth',
+          data: {
+            labels: countries.map((d) => d.properties.name),
+            datasets: [{
+              label: 'Countries',
+              data: countries.map((d) => {
+                const country = country_values.filter(x => x.country_numeric === d.id)[0];
+                if (country === undefined) {
+                  return {feature: d, value: 0};
+                } else {
+                  return {feature: d, value: Math.log(country.sessions)};
+                }
+              }),
+            }]
+          },
+          options: {
+            showOutline: true,
+            showGraticule: false,
+            plugins: {
+              tooltip: {
+                callbacks: {
+                  label(item) {
+                    if (item.raw.value === 0) {
+                      return `${item.chart.data.labels[item.dataIndex]}: 0`;
+                    } else {
+                      return `${item.chart.data.labels[item.dataIndex]}: ${Math.ceil(Math.exp(item.raw.value))}`;
+                    }
+                  },
                 },
               },
+              legend: {
+                display: false
+              },
             },
-            legend: {
-              display: false
-            },
-          },
-          scales: {
-            xy: {
-              projection: 'equalEarth'
-            },
-            color: {
-              display:false,
-            },
+            scales: {
+              xy: {
+                projection: 'equalEarth'
+              },
+              color: {
+                display:false,
+              },
+            }
           }
-        }
-      });
-    });
+        });
+      } catch (error) {
+        alert('Something went wrong, try again.');
+        throw error;
+      }
+    }
+    initChart();
   </script>
 {% endblock %}

--- a/isic/studies/templates/studies/study_task_detail.html
+++ b/isic/studies/templates/studies/study_task_detail.html
@@ -20,22 +20,19 @@
     <script type="text/javascript">
       function undoStudyTask() {
         return {
-          undo: function() {
-            fetch('{% url "api:study_task_undo" just_completed_task.id %}', {
-              method: 'POST',
-              headers: {
-                'X-CSRFToken': '{{ csrf_token }}',
-              },
-            }).then(response => {
-              if (response.ok) {
-                window.location.href = '{% url "studies/study-task-detail" just_completed_task.id %}';
-              } else {
-                alert('An error occurred.');
-              }
-            }).catch(error => {
-              console.error('Error:', error);
-              alert('An error occurred.');
-            });
+          undo: async function() {
+            try {
+              const resp = await fetch('{% url "api:study_task_undo" just_completed_task.id %}', {
+                method: 'POST',
+                headers: {
+                  'X-CSRFToken': '{{ csrf_token }}',
+                },
+              });
+              window.location.href = '{% url "studies/study-task-detail" just_completed_task.id %}';
+            } catch (error) {
+              alert('Something went wrong, try again.');
+              throw error;
+            }
           }
         }
       }


### PR DESCRIPTION
In response to these comments on #1519: [x](https://github.com/ImageMarkup/isic/pull/1519#discussion_r3384920899), [x](https://github.com/ImageMarkup/isic/pull/1519#discussion_r3384934182), [x](https://github.com/ImageMarkup/isic/pull/1519#issuecomment-4672441772).

This PR refactors all instances of `.then` as `async/await` functions with `try/catch` blocks for more consistent error handling. If an error is encountered, we send a generic alert to the user and rethrow the error so it can be captured by Sentry.