### PR TITLE
Repoint core.0002_initial to the squashed ingest migration

### DIFF
--- a/isic/core/migrations/0002_initial.py
+++ b/isic/core/migrations/0002_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("core", "0001_initial"),
-        ("ingest", "0001_initial"),
+        ("ingest", "0001_initial_squashed_0032_alter_metadataversion_created_and_more"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
`core.0002_initial` depended on `("ingest", "0001_initial")`, but that file was deleted when migrations `0001`–`0032` were squashed into `0001_initial_squashed_0032_alter_metadataversion_created_and_more`. `makemigrations`/`migrate` hid this because they load the graph with `replace_migrations=True` and collapse the squash. `sqlmigrate` uses `replace_migrations=False`, so the squash is not collapsed and the dangling dependency on the deleted `ingest.0001_initial` raised `NodeNotFoundError`, breaking `sqlmigrate` for every `ingest` migration.