### PR TITLE
Fix flaky collection picker ordering in browser test

### DIFF
--- a/isic/core/tests/image_browser/test_browser.py
+++ b/isic/core/tests/image_browser/test_browser.py
@@ -2,6 +2,7 @@ from django.urls import reverse
 from playwright.sync_api import expect
 import pytest
 
+from isic.core.models.collection import Collection
 from isic.core.services.collection.image import add_images_to_collection
 
 
@@ -9,9 +10,12 @@ from isic.core.services.collection.image import add_images_to_collection
 def test_collection_picker_dropdown_filter_select_and_keyboard(
     page, collection_factory, image_factory
 ):
-    collections = [collection_factory(public=True, pinned=True) for _ in range(3)]
-    # The picker sorts alphabetically by name
-    collections.sort(key=lambda c: c.name)
+    for _ in range(3):
+        collection_factory(public=True, pinned=True)
+
+    # Read the collections back in the picker's display order. The dropdown
+    # renders them in the server's order (Postgres `ORDER BY name`).
+    collections = list(Collection.objects.pinned().order_by("name"))
 
     # Create images and assign them to specific collections so we can verify
     # that filtering by collection shows only the correct images.


### PR DESCRIPTION
The test computed the expected collection order with Python's
`sort(key=lambda c: c.name)`, but the picker dropdown renders collections
in the server's order (`Collection.objects.pinned().order_by("name")`),
which uses the database's collation. Postgres' en_US.utf8 collation ignores
spaces, punctuation, and case at the primary level, so it can disagree with
Python's codepoint sort (e.g. "Cat dog." sorts before "Catalog end." in
Python but after it in Postgres).

When faker happened to generate names that triggered this divergence, the
test's first/second/third no longer matched the dropdown's display order,
and the keyboard-navigation assertions (which select the 2nd/last displayed
option) failed intermittently.
