### PR TITLE
Use exact match for Search button in collection picker test

### DIFF
--- a/isic/core/tests/image_browser/test_browser.py
+++ b/isic/core/tests/image_browser/test_browser.py
@@ -78,7 +78,7 @@ def test_collection_picker_dropdown_filter_select_and_keyboard(
 
     # Submit the form and verify only images from the selected collections are shown.
     # second and third are selected; first was removed.
-    page.get_by_role("button", name="Search").click()
+    page.get_by_role("button", name="Search", exact=True).click()
     page.wait_for_load_state("networkidle")
 
     page_text = page.text_content("body")


### PR DESCRIPTION
Playwright's name= filter does case-insensitive substring matching by default, so get_by_role("button", name="Search") also matched a collection's "Remove ..." badge button whenever Faker generated a collection name containing the substring "search". For example:

    strict mode violation: get_by_role("button", name="Search")
    resolved to 2 elements:
      1) <button aria-label="Remove Program law test star research present.">
      2) <button type="submit">Search</button>

"Remove Program law test star research present." contains "research", whose "search" substring matched the locator. Passing exact=True pins the locator to the submit button regardless of collection names.