### PR TITLE
Require authentication for similar images

### DIFF
--- a/isic/core/api/image.py
+++ b/isic/core/api/image.py
@@ -11,11 +11,13 @@ from ninja.pagination import paginate
 from pyparsing.exceptions import ParseException
 from sentry_sdk import set_tag
 
+from isic.auth import is_authenticated
 from isic.core.models import Image
 from isic.core.pagination import CursorPagination, qs_with_hardcoded_count
 from isic.core.permissions import get_visible_objects
 from isic.core.search import facets, get_elasticsearch_client
 from isic.core.serializers import SearchQueryIn
+from isic.types import AuthenticatedHttpRequest
 
 router = Router()
 
@@ -196,9 +198,10 @@ class SimilarImageOut(ImageOut):
     response=list[SimilarImageOut],
     summary="Find images similar to the specified image.",
     include_in_schema=True,
+    auth=is_authenticated,
 )
 def image_similar(
-    request: HttpRequest, isic_id: str, limit: int = Query(10, le=50)
+    request: AuthenticatedHttpRequest, isic_id: str, limit: int = Query(10, le=50)
 ) -> list[SimilarImageOut]:
     qs = get_visible_objects(request.user, "core.view_image", default_qs)
     image = get_object_or_404(qs, isic_id=isic_id)

--- a/isic/core/tests/test_api_image.py
+++ b/isic/core/tests/test_api_image.py
@@ -83,7 +83,7 @@ def test_api_image_search_size(client, searchable_images_with_size):
 
 
 @pytest.mark.django_db
-def test_api_image_similar_images(client, image_factory, image_embedding_factory):
+def test_api_image_similar_images(authenticated_client, image_factory, image_embedding_factory):
     image_with_embedding = image_embedding_factory(image__public=True).image
     other_image = image_embedding_factory(image__public=True).image
 
@@ -97,7 +97,7 @@ def test_api_image_similar_images(client, image_factory, image_embedding_factory
         cursor.execute("SET enable_indexscan = off")
 
     url = reverse("api:image_similar", kwargs={"isic_id": image_with_embedding.isic_id})
-    r = client.get(url)
+    r = authenticated_client.get(url)
     assert r.status_code == 200
     results = r.json()
     assert len(results) == 1
@@ -106,10 +106,19 @@ def test_api_image_similar_images(client, image_factory, image_embedding_factory
 
 
 @pytest.mark.django_db
-def test_api_image_similar_images_without_embedding(client, image_factory):
+def test_api_image_similar_images_requires_login(client, image_embedding_factory):
+    image_with_embedding = image_embedding_factory(image__public=True).image
+
+    url = reverse("api:image_similar", kwargs={"isic_id": image_with_embedding.isic_id})
+    r = client.get(url)
+    assert r.status_code == 401
+
+
+@pytest.mark.django_db
+def test_api_image_similar_images_without_embedding(authenticated_client, image_factory):
     image_without_embedding = image_factory(public=True)
 
     url = reverse("api:image_similar", kwargs={"isic_id": image_without_embedding.isic_id})
-    r = client.get(url)
+    r = authenticated_client.get(url)
     assert r.status_code == 200
     assert r.json() == []

--- a/isic/core/views/images.py
+++ b/isic/core/views/images.py
@@ -130,7 +130,7 @@ def image_detail(request, isic_id):
         "studies": f"Studies ({studies.count()})",
     }
 
-    if image.has_embedding:
+    if image.has_embedding and request.user.is_authenticated:
         ctx["sections"]["similar_images"] = "Similar Images"
 
     if ctx["other_patient_images_count"]:


### PR DESCRIPTION
At the moment this is facing performance issues and since it's an intensive operation it's being gated for now.