### PR TITLE
Pin pgvector to 0.8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     services:
       postgres:
-        image: pgvector/pgvector:pg18
+        image: pgvector/pgvector:0.8.3-pg18
         env:
           POSTGRES_DB: django
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: pgvector/pgvector:pg18
+    image: pgvector/pgvector:0.8.3-pg18
     shm_size: 128mb
     # Bumped so the core_imageembedding ivfflat index can build during greenmask
     # restores.


### PR DESCRIPTION
Tests are failing under pgvector 0.8.4, likely due to this commit: https://github.com/pgvector/pgvector/commit/bdf19077db1061b4139199c67ba21281f3ed3766

Even after we resolve the bug, we should try to keep the pin. Renovate should be able to bump the version.