### PR TITLE
Apply requested ordering to only to new cursors

### DIFF
--- a/isic/core/api/image.py
+++ b/isic/core/api/image.py
@@ -153,10 +153,13 @@ class PinnedFirstPagination(CursorPagination):
         return "|".join(values)
 
     def paginate_queryset(self, queryset, pagination, request, **params):
-        if request.GET.get("pin_sort") or params.get("pin_sort"):
-            queryset = queryset.order_by("-pinned", "created")
-        else:
-            queryset = queryset.order_by("created")
+        if pagination.cursor.position is None:
+            # New cursor, apply ordering according to pin_sort param
+            if request.GET.get("pin_sort") or params.get("pin_sort"):
+                self.ordering = ("-pinned", "created")
+            else:
+                self.ordering = ("created",)
+        queryset = queryset.order_by(*self.ordering)
         return super().paginate_queryset(queryset, pagination, request, **params)
 
 

--- a/isic/core/tests/test_image_pin.py
+++ b/isic/core/tests/test_image_pin.py
@@ -59,6 +59,36 @@ def test_core_api_image_sort_by_pinned(image_factory, authenticated_client):
     assert ordered_ids == [image_2.isic_id, image_1.isic_id]
 
 
+@pytest.mark.parametrize("pin_sort", [True, False])
+@pytest.mark.django_db
+def test_images_pagination_prevent_switch_ordering(image_factory, authenticated_client, pin_sort):
+    images = [image_factory(public=True, pinned=(i % 2 == 0)) for i in range(10)]
+    if pin_sort:
+        expected_ids = [images[i].isic_id for i in [0, 2, 4, 6, 8, 1, 3, 5, 7, 9]]
+    else:
+        expected_ids = [image.isic_id for image in images]
+
+    # Apply pin sort to first request
+    query = {"limit": 5}
+    if pin_sort:
+        query["pin_sort"] = True
+    r = authenticated_client.get(reverse("api:image_list"), data=query).json()
+    result_ids = [image.get("isic_id") for image in r.get("results")]
+    assert result_ids == expected_ids[0:5]
+
+    # Switch pin sort on next request
+    next_url = r.get("next")
+    if pin_sort:
+        next_url = next_url.replace("&pin_sort=True", "")
+    else:
+        next_url += "&pin_sort=True"
+
+    # pin sort switch should be ignored, continue with initial ordering
+    r = authenticated_client.get(next_url).json()
+    result_ids = [image.get("isic_id") for image in r.get("results")]
+    assert result_ids == expected_ids[5:10]
+
+
 @pytest.mark.playwright
 def test_image_pin_unpin(image_factory, staff_authenticated_page):
     page = staff_authenticated_page


### PR DESCRIPTION
[This issue in Sentry](https://kitware-data.sentry.io/issues/7590475145/) has been occurring since the introduction of the `PinnedFirstPagination` class. The error `ValueError("Cursor position does not match the current ordering.")` is raised when an existing cursor is later passed `pin_sort=True`. This PR adjusts the logic in `paginate_queryset` such that we only adjust the ordering if we are creating a new cursor (if `pagination.cursor.position` is None). If the cursor already has a position, continue with the same ordering regardless of whether `pin_sort=True` is present in the current request.

This PR also adds a test to confirm that the error is no longer raised if we try to change the ordering on an existing cursor.