### PR TITLE
Reorder Image Pins

### DIFF
--- a/isic/core/api/image.py
+++ b/isic/core/api/image.py
@@ -371,4 +371,5 @@ def image_pins_reorder(request: HttpRequest, payload: PinOrder):
             # pins are 1-indexed; 0 is unpinned
             image.pinned = i + 1
             image.save()
+    messages.add_message(request, messages.SUCCESS, "Reordered pinned images.")
     return 200, None

--- a/isic/core/api/image.py
+++ b/isic/core/api/image.py
@@ -364,6 +364,9 @@ def image_pins_reorder(request: HttpRequest, payload: PinOrder):
     if not request.user.is_staff:
         return 403, {"error": "You do not have permission to reorder image pins."}
 
+    if Image.objects.filter(isic_id__in=payload.order).count() != len(payload.order):
+        return 400, {"error": "Invalid ISIC ID list."}
+
     with transaction.atomic():
         # pins are sorted in descending order, so reverse ordered list
         for i, isic_id in enumerate(reversed(payload.order)):

--- a/isic/core/api/image.py
+++ b/isic/core/api/image.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.cache import cache
 from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
 from django.db.models import Max, Q
 from django.http.request import HttpRequest
 from django.shortcuts import get_object_or_404
@@ -326,6 +327,7 @@ class SetPinned(Schema):
     "/{id}/set-pinned/",
     response={200: None, 400: dict, 403: dict},
     include_in_schema=False,
+    auth=is_authenticated,
 )
 def image_set_pinned(request, id: int, payload: SetPinned):
     if not request.user.is_staff:
@@ -343,4 +345,30 @@ def image_set_pinned(request, id: int, payload: SetPinned):
     image.save()
     action = "pinned" if payload.pinned else "unpinned"
     messages.add_message(request, messages.SUCCESS, f"Image {action}.")
+    return 200, None
+
+
+class PinOrder(Schema):
+    order: list[str]
+
+    model_config = {"extra": "forbid"}
+
+
+@router.post(
+    "/pins/reorder/",
+    response={200: None, 400: dict, 403: dict},
+    include_in_schema=False,
+    auth=is_authenticated,
+)
+def image_pins_reorder(request: HttpRequest, payload: PinOrder):
+    if not request.user.is_staff:
+        return 403, {"error": "You do not have permission to reorder image pins."}
+
+    with transaction.atomic():
+        # pins are sorted in descending order, so reverse ordered list
+        for i, isic_id in enumerate(reversed(payload.order)):
+            image = Image.objects.get(isic_id=isic_id)
+            # pins are 1-indexed; 0 is unpinned
+            image.pinned = i + 1
+            image.save()
     return 200, None

--- a/isic/core/api/image.py
+++ b/isic/core/api/image.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.core.cache import cache
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
-from django.db.models import Max, Q
+from django.db.models import Case, Max, Q, Value, When
 from django.http.request import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
@@ -364,15 +364,20 @@ def image_pins_reorder(request: HttpRequest, payload: PinOrder):
     if not request.user.is_staff:
         return 403, {"error": "You do not have permission to reorder image pins."}
 
-    if Image.objects.filter(isic_id__in=payload.order).count() != len(payload.order):
-        return 400, {"error": "Invalid ISIC ID list."}
-
     with transaction.atomic():
-        # pins are sorted in descending order, so reverse ordered list
-        for i, isic_id in enumerate(reversed(payload.order)):
-            image = Image.objects.get(isic_id=isic_id)
-            # pins are 1-indexed; 0 is unpinned
-            image.pinned = i + 1
-            image.save()
+        result = Image.objects.filter(public=True, isic_id__in=payload.order).update(
+            pinned=Case(
+                *[
+                    # pins are sorted in descending order, so reverse ordered list.
+                    # pins are 1-indexed; 0 is unpinned.
+                    When(isic_id=isic_id, then=Value(i))
+                    for i, isic_id in enumerate(reversed(payload.order), start=1)
+                ]
+            )
+        )
+        if result != len(payload.order):
+            transaction.set_rollback(True)
+            return 400, {"error": "Invalid ISIC ID list."}
+
     messages.add_message(request, messages.SUCCESS, "Reordered pinned images.")
     return 200, None

--- a/isic/core/templates/core/base.html
+++ b/isic/core/templates/core/base.html
@@ -18,6 +18,7 @@
       <script src="https://js.sentry-cdn.com/81572a3d084f4fef90e093440762cedd.min.js" crossorigin="anonymous"></script>
     {% endif %}
     <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/sort@3.x.x/dist/cdn.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.26.0/axios.min.js" integrity="sha512-bPh3uwgU5qEMipS/VOmRqynnMXGGSRv+72H/N260MQeXZIK4PG48401Bsby9Nq5P5fz7hy5UGNmC/W1Z51h2GQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 

--- a/isic/core/templates/core/image_pins.html
+++ b/isic/core/templates/core/image_pins.html
@@ -1,0 +1,57 @@
+{% extends 'core/base.html' %}
+
+{% block content %}
+  {% if request.user.is_staff %}
+    <script>
+      function imagePins() {
+        return {
+          pinOrder: undefined,
+          init() {
+            this.orderUpdated();
+          },
+          orderUpdated(itemId, position) {
+            this.pinOrder = $('#image-grid').children().map(
+              (i, item) => $(item).attr('x-sort:item').replaceAll("'", "")
+            ).get();
+          },
+          async submitPinOrder() {
+            try {
+              const resp = await axios.post(
+                `/api/v2/images/pins/reorder/`,
+                {"order": this.pinOrder},
+                {
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': '{{ csrf_token }}'
+                  }
+                },
+              );
+              window.location.reload();
+            } catch (error) {
+              alert('Something went wrong, try again.');
+              throw error;
+            }
+          }
+        }
+      }
+    </script>
+
+    <div x-data="imagePins()">
+      <div class="flex justify-between items-center mb-2">
+        <div>Drag to reorder pinned images, then submit changes by clicking "Save".</div>
+        <button type="submit" class="btn btn-primary" @click="submitPinOrder">
+          Save
+        </button>
+      </div>
+      <div
+        id="image-grid"
+        x-sort="orderUpdated()"
+        class="grid gap-4 grid-cols-8"
+      >
+        {% for image in pinned %}
+          {% include 'core/partials/image.html' %}
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/isic/core/templates/core/image_pins.html
+++ b/isic/core/templates/core/image_pins.html
@@ -4,9 +4,14 @@
   <script>
     function imagePins() {
       return {
-        pinOrder: undefined,
+        pinOrder: [],
+        initialPinOrder: [],
         init() {
           this.orderUpdated();
+          this.initialPinOrder = this.pinOrder;
+        },
+        get orderChanged() {
+          return this.pinOrder.join() !== this.initialPinOrder.join();
         },
         orderUpdated() {
           this.pinOrder = [...document.getElementById('image-grid').children].map(
@@ -38,7 +43,7 @@
   <div x-data="imagePins()">
     <div class="flex justify-between items-center mb-2">
       <div>Drag to reorder pinned images, then submit changes by clicking "Save".</div>
-      <button type="submit" class="btn btn-primary" @click="submitPinOrder">
+      <button type="submit" class="btn btn-primary" :disabled="!orderChanged" @click="submitPinOrder">
         Save
       </button>
     </div>

--- a/isic/core/templates/core/image_pins.html
+++ b/isic/core/templates/core/image_pins.html
@@ -1,57 +1,55 @@
 {% extends 'core/base.html' %}
 
 {% block content %}
-  {% if request.user.is_staff %}
-    <script>
-      function imagePins() {
-        return {
-          pinOrder: undefined,
-          init() {
-            this.orderUpdated();
-          },
-          orderUpdated(itemId, position) {
-            this.pinOrder = $('#image-grid').children().map(
-              (i, item) => $(item).attr('x-sort:item').replaceAll("'", "")
-            ).get();
-          },
-          async submitPinOrder() {
-            try {
-              const resp = await axios.post(
-                `/api/v2/images/pins/reorder/`,
-                {"order": this.pinOrder},
-                {
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': '{{ csrf_token }}'
-                  }
-                },
-              );
-              window.location.reload();
-            } catch (error) {
-              alert('Something went wrong, try again.');
-              throw error;
-            }
+  <script>
+    function imagePins() {
+      return {
+        pinOrder: undefined,
+        init() {
+          this.orderUpdated();
+        },
+        orderUpdated() {
+          this.pinOrder = [...document.getElementById('image-grid').children].map(
+            (item) => item.getAttribute('x-sort:item').replaceAll("'", "")
+          );
+        },
+        async submitPinOrder() {
+          try {
+            const resp = await axios.post(
+              `/api/v2/images/pins/reorder/`,
+              {"order": this.pinOrder},
+              {
+                headers: {
+                  'Content-Type': 'application/json',
+                  'X-CSRFToken': '{{ csrf_token }}'
+                }
+              },
+            );
+            window.location.reload();
+          } catch (error) {
+            alert('Something went wrong, try again.');
+            throw error;
           }
         }
       }
-    </script>
+    }
+  </script>
 
-    <div x-data="imagePins()">
-      <div class="flex justify-between items-center mb-2">
-        <div>Drag to reorder pinned images, then submit changes by clicking "Save".</div>
-        <button type="submit" class="btn btn-primary" @click="submitPinOrder">
-          Save
-        </button>
-      </div>
-      <div
-        id="image-grid"
-        x-sort="orderUpdated()"
-        class="grid gap-4 grid-cols-8"
-      >
-        {% for image in pinned %}
-          {% include 'core/partials/image.html' %}
-        {% endfor %}
-      </div>
+  <div x-data="imagePins()">
+    <div class="flex justify-between items-center mb-2">
+      <div>Drag to reorder pinned images, then submit changes by clicking "Save".</div>
+      <button type="submit" class="btn btn-primary" @click="submitPinOrder">
+        Save
+      </button>
     </div>
-  {% endif %}
+    <div
+      id="image-grid"
+      x-sort="orderUpdated()"
+      class="grid gap-4 grid-cols-8"
+    >
+      {% for image in pinned %}
+        {% include 'core/partials/image.html' %}
+      {% endfor %}
+    </div>
+  </div>
 {% endblock %}

--- a/isic/core/templates/core/partials/image.html
+++ b/isic/core/templates/core/partials/image.html
@@ -1,6 +1,6 @@
 {% load accession %}
 
-<div>
+<div x-sort:item="'{{image.isic_id}}'">
   <div x-data="{ hovered: false }" class="pb-4">
     {% block thumb %}
       {% include 'core/partials/image_thumb.html' %}

--- a/isic/core/templates/core/partials/nav_elements.html
+++ b/isic/core/templates/core/partials/nav_elements.html
@@ -8,6 +8,7 @@
         <li><a href="{% url 'ingest/ingest-review' %}">Ingest Review</a></li>
         <li><a href="{% url 'ingest/cohort-list' %}">Cohort List</a></li>
         <li><a href="{% url 'core/embargoed-dashboard' %}">Embargoed Images</a></li>
+        <li><a href="{% url 'core/image-pins' %}">Reorder Pinned Images</a></li>
         <li><a href="{% url 'core/image-list-export' %}">Image List</a></li>
         <li><a href="{% url 'core/staff-list' %}">Users</a></li>
         <li><a target="blank" href="{% url 'admin:index' %}">Django Admin <i class="ri-external-link-line"></i></a></li>

--- a/isic/core/tests/test_image_pin.py
+++ b/isic/core/tests/test_image_pin.py
@@ -138,3 +138,13 @@ def test_core_api_image_reorder_pins(client_, expected_status, image_factory):
 
     r = client_.get(reverse("api:image_list"), data={"pin_sort": True})
     assert [image.get("isic_id") for image in r.json().get("results")] == expected_order
+
+
+@pytest.mark.django_db
+def test_core_api_image_reorder_pins_invalid_id(staff_client):
+    r = staff_client.post(
+        reverse("api:image_pins_reorder"),
+        {"order": ["foo"]},
+        content_type="application/json",
+    )
+    assert r.status_code == 400

--- a/isic/core/tests/test_image_pin.py
+++ b/isic/core/tests/test_image_pin.py
@@ -8,7 +8,7 @@ from pytest_lazy_fixtures import lf
 @pytest.mark.parametrize(
     ("client_", "expected_status"),
     [
-        (lf("client"), 403),
+        (lf("client"), 401),
         (lf("authenticated_client"), 403),
         (lf("staff_client"), 200),
     ],
@@ -95,3 +95,46 @@ def test_image_pin_disabled_when_private(image_factory, staff_authenticated_page
     pin_button = page.get_by_role("button", name="Pin image")
     expect(pin_button).to_be_disabled()
     expect(pin_button).to_have_accessible_description("Only public images can be pinned")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("client_", "expected_status"),
+    [
+        (lf("client"), 401),
+        (lf("authenticated_client"), 403),
+        (lf("staff_client"), 200),
+    ],
+    ids=["anonymous", "authenticated", "staff"],
+)
+def test_core_api_image_reorder_pins(client_, expected_status, image_factory):
+    images = [
+        image_factory(public=True),
+        image_factory(public=True, pinned=1),
+        image_factory(public=True, pinned=2),
+    ]
+    expected_order = [
+        images[2].isic_id,
+        images[1].isic_id,
+        images[0].isic_id,
+    ]
+
+    r = client_.get(reverse("api:image_list"), data={"pin_sort": True})
+    assert [image.get("isic_id") for image in r.json().get("results")] == expected_order
+
+    r = client_.post(
+        reverse("api:image_pins_reorder"),
+        {"order": [images[1].isic_id, images[2].isic_id]},
+        content_type="application/json",
+    )
+    assert r.status_code == expected_status
+
+    if expected_status == 200:
+        expected_order = [
+            images[1].isic_id,
+            images[2].isic_id,
+            images[0].isic_id,
+        ]
+
+    r = client_.get(reverse("api:image_list"), data={"pin_sort": True})
+    assert [image.get("isic_id") for image in r.json().get("results")] == expected_order

--- a/isic/core/tests/test_image_pin.py
+++ b/isic/core/tests/test_image_pin.py
@@ -171,6 +171,9 @@ def test_image_pins_reorder_drag(staff_authenticated_page, image_factory):
     items = page.locator("#image-grid > div")
     expect(items).to_have_count(2)
 
+    save_button = page.get_by_role("button", name="Save")
+    expect(save_button).to_be_disabled()
+
     # drag the first image onto the second. sortable tracks intermediate mouse
     # moves, so a single jump to the target isn't enough to register the swap.
     target = items.nth(1).bounding_box()
@@ -179,7 +182,8 @@ def test_image_pins_reorder_drag(staff_authenticated_page, image_factory):
     page.mouse.move(target["x"] + target["width"] / 2, target["y"] + target["height"] / 2, steps=10)
     page.mouse.up()
 
-    page.get_by_role("button", name="Save").click()
+    expect(save_button).to_be_enabled()
+    save_button.click()
 
     # saving reloads the page, so the new order and the message come from the server
     expect(page.get_by_text("Reordered pinned images.")).to_be_visible()

--- a/isic/core/tests/test_image_pin.py
+++ b/isic/core/tests/test_image_pin.py
@@ -3,6 +3,8 @@ from playwright.sync_api import expect
 import pytest
 from pytest_lazy_fixtures import lf
 
+from isic.ingest.tests.factories import data_dir
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
@@ -148,3 +150,38 @@ def test_core_api_image_reorder_pins_invalid_id(staff_client):
         content_type="application/json",
     )
     assert r.status_code == 400
+
+
+@pytest.mark.playwright
+def test_image_pins_reorder_drag(staff_authenticated_page, image_factory):
+    page = staff_authenticated_page
+    # distinct thumbnail sources make the swap easier to view when running headed
+    first = image_factory(
+        public=True,
+        pinned=2,
+        accession__sponsored_thumbnail_256_blob__from_path=data_dir / "ISIC_0000001.jpg",
+    )
+    second = image_factory(
+        public=True,
+        pinned=1,
+        accession__sponsored_thumbnail_256_blob__from_path=data_dir / "ISIC_0000002.jpg",
+    )
+
+    page.goto(reverse("core/image-pins"))
+    items = page.locator("#image-grid > div")
+    expect(items).to_have_count(2)
+
+    # drag the first image onto the second. sortable tracks intermediate mouse
+    # moves, so a single jump to the target isn't enough to register the swap.
+    target = items.nth(1).bounding_box()
+    items.nth(0).hover()
+    page.mouse.down()
+    page.mouse.move(target["x"] + target["width"] / 2, target["y"] + target["height"] / 2, steps=10)
+    page.mouse.up()
+
+    page.get_by_role("button", name="Save").click()
+
+    # saving reloads the page, so the new order and the message come from the server
+    expect(page.get_by_text("Reordered pinned images.")).to_be_visible()
+    expect(items.nth(0).get_by_role("link", name=second.isic_id)).to_be_visible()
+    expect(items.nth(1).get_by_role("link", name=first.isic_id)).to_be_visible()

--- a/isic/core/urls.py
+++ b/isic/core/urls.py
@@ -17,6 +17,7 @@ from isic.core.views.images import (
     image_detail,
     staff_image_list_export,
     staff_image_list_metadata_download,
+    staff_image_pins,
 )
 from isic.core.views.lesion import lesion_detail
 from isic.core.views.users import staff_list, user_detail
@@ -80,6 +81,7 @@ urlpatterns = [
         name="core/user-detail",
     ),
     path("staff/image-list/", staff_image_list_export, name="core/image-list-export"),
+    path("staff/image-pins/", staff_image_pins, name="core/image-pins"),
     path(
         "staff/image-list/metadata-download/",
         staff_image_list_metadata_download,

--- a/isic/core/views/images.py
+++ b/isic/core/views/images.py
@@ -225,3 +225,12 @@ def staff_image_list_metadata_download(request: AuthenticatedHttpRequest):
     )
 
     return HttpResponseRedirect(reverse("core/image-list-export"))
+
+
+@staff_member_required
+def staff_image_pins(request: AuthenticatedHttpRequest) -> HttpResponse:
+    return render(
+        request,
+        "core/image_pins.html",
+        {"pinned": Image.objects.filter(pinned__gte=1).order_by("-pinned")},
+    )

--- a/isic/core/views/images.py
+++ b/isic/core/views/images.py
@@ -232,5 +232,9 @@ def staff_image_pins(request: AuthenticatedHttpRequest) -> HttpResponse:
     return render(
         request,
         "core/image_pins.html",
-        {"pinned": Image.objects.filter(pinned__gte=1).order_by("-pinned")},
+        {
+            "pinned": Image.objects.filter(pinned__gte=1)
+            .select_related("accession")
+            .order_by("-pinned")
+        },
     )


### PR DESCRIPTION
This PR adds a new page for staff members to reorder pinned images (accessed via the staff menu). The new page leverages the [AlpineJS Sort plugin](https://alpinejs.dev/plugins/sort#basic-usage) so that staff users can simply drag pinned images to the desired position. After dragging to reorder the pinned images, the staff user must submit the changes with the Save button, which makes a call to a new API endpoint. The endpoint accepts the new order as a list of ISIC IDs. This PR also includes a test for the new endpoint.