### PR TITLE
Fix failure when merging empty cohorts

### DIFF
--- a/isic/ingest/services/cohort/__init__.py
+++ b/isic/ingest/services/cohort/__init__.py
@@ -37,9 +37,9 @@ def merge_cohorts(*, dest_cohort: Cohort, src_cohort: Cohort) -> None:
     an unexpected state otherwise.
     """
     overlapping_blob_names = (
-        Cohort.objects.filter(id__in=[dest_cohort.id, src_cohort.id])
-        .values("accessions__original_blob_name")
-        .annotate(c=Count("id"))
+        Accession.objects.filter(cohort__in=[dest_cohort, src_cohort])
+        .values("original_blob_name")
+        .annotate(c=Count("cohort", distinct=True))
         .filter(c__gt=1)
     )
 


### PR DESCRIPTION
The overlapping blob name check in merge_cohorts started from Cohort and traversed the reverse accessions relation, which produces a LEFT JOIN. When neither cohort has any accessions, both cohort rows come back with a NULL original_blob_name, which groups into a single row with a count of 2. That looks identical to a real conflict, so merging two accession-less cohorts always failed with "Found 1 conflicting original blob names."

Start the query from Accession instead, so rows only exist for accessions that actually exist, and count distinct cohorts per blob name. The distinct count also makes the intent explicit: the check is about the same blob name appearing in both cohorts, not about duplicates within one cohort (which the unique_together on (cohort, original_blob_name) already prevents).