### PR TITLE
Ask greenmask whether a dump exists instead of globbing for one

### DIFF
--- a/dev/greenmask-dump.sh
+++ b/dev/greenmask-dump.sh
@@ -58,8 +58,7 @@ readonly LOG_LEVEL=info
 mkdir -p ./.greenmask/dumps
 
 if [[ "$REUSE_EXISTING_DUMP" -eq 1 ]]; then
-  # Check for at least one dump file in ./.greenmask/dumps
-  if ! ls ./.greenmask/dumps/*.sql.pgz >/dev/null 2>&1; then
+  if [[ -z "$(greenmask list-dumps --quiet)" ]]; then
     echo "No existing dump found to reuse. Please run without -r/--reuse-existing-dump first." >&2
     exit 1
   fi


### PR DESCRIPTION
The -r/--reuse-existing-dump guard checked for
./.greenmask/dumps/*.sql.pgz, but the directory storage backend has never written a file by that name -- a dump is a directory of per-table .dat.gz members alongside toc.dat and metadata.json, and --pgzip compresses those members rather than producing a single archive. The glob therefore never matched and -r always aborted, no matter how many dumps were present.

Use `greenmask list-dumps --quiet`, which prints one dump id per line (newest first) and prints nothing on empty storage, so the dump layout stays greenmask's business. It reads .greenmask/config.yml via GREENMASK_CONFIG like the other subcommands and works with DATABASE_URL unset, which matters because the reuse path deliberately skips the Heroku credential lookup.