### PR TITLE
Add __str__ to remaining studies models

### DIFF
--- a/isic/studies/admin.py
+++ b/isic/studies/admin.py
@@ -67,6 +67,15 @@ class AnnotationInline(ReadonlyTabularInline):
 class MarkupAdmin(StaffReadonlyAdmin):
     list_display = ["annotation", "feature", "present"]
 
+    def get_queryset(self, request: HttpRequest) -> QuerySet[Any]:
+        return (
+            super()
+            .get_queryset(request)
+            .select_related(
+                "feature", "annotation__image", "annotation__study", "annotation__annotator"
+            )
+        )
+
 
 @admin.register(QuestionChoice)
 class QuestionChoiceAdmin(StaffReadonlyAdmin):

--- a/isic/studies/models/annotation.py
+++ b/isic/studies/models/annotation.py
@@ -35,6 +35,9 @@ class Annotation(TimeStampedModel):
     # all annotations created by this app submit a start_time.
     start_time = models.DateTimeField(null=True)
 
+    def __str__(self) -> str:
+        return f"{self.image} by {self.annotator} in {self.study}"
+
     def get_absolute_url(self) -> str:
         return reverse("studies/annotation-detail", args=[self.pk])
 

--- a/isic/studies/models/markup.py
+++ b/isic/studies/models/markup.py
@@ -16,3 +16,6 @@ class Markup(TimeStampedModel):
     feature = models.ForeignKey(Feature, on_delete=models.PROTECT, related_name="markups")
     mask = S3FileField(upload_to=generate_upload_to)
     present = models.BooleanField()
+
+    def __str__(self) -> str:
+        return f"{self.feature} ({'present' if self.present else 'absent'})"

--- a/isic/studies/models/response.py
+++ b/isic/studies/models/response.py
@@ -116,3 +116,6 @@ class Response(TimeStampedModel):
     )
     # expect a single key inside named value. TODO: maybe add a constraint for this.
     value = models.JSONField(null=True)
+
+    def __str__(self) -> str:
+        return f"{self.question}: {self.choice or self.value}"

--- a/isic/studies/models/study_task.py
+++ b/isic/studies/models/study_task.py
@@ -43,6 +43,9 @@ class StudyTask(TimeStampedModel):
 
     objects = StudyTaskQuerySet.as_manager()
 
+    def __str__(self) -> str:
+        return f"{self.image} for {self.annotator} in {self.study}"
+
     @property
     def complete(self) -> bool:
         return hasattr(self, "annotation")


### PR DESCRIPTION
Annotation, StudyTask, Response, and Markup all rendered as "<Model> object (pk)" in the admin, including in list_display columns and inlines. Every other model in the app already defines __str__.

Markup's list_display renders the annotation, so select_related the relations that Annotation.__str__ now traverses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced administrative views for markup records by loading related study, image, annotation, and annotator details more efficiently.
  - Added clearer labels for annotations, markups, responses, and study tasks, making records easier to identify and interpret.
  - Markups now indicate whether each feature is present or absent, while responses display the associated question and selected value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->